### PR TITLE
add TimestampedModel abstract base and uuid7() default callable

### DIFF
--- a/core/models.py
+++ b/core/models.py
@@ -1,1 +1,9 @@
-# Create your models here.
+from django.db import models
+
+
+class TimestampedModel(models.Model):
+    created_at = models.DateTimeField(auto_now_add=True)
+    updated_at = models.DateTimeField(auto_now=True)
+
+    class Meta:
+        abstract = True

--- a/core/utils/ids.py
+++ b/core/utils/ids.py
@@ -1,0 +1,3 @@
+from uuid import uuid7
+
+__all__ = ["uuid7"]

--- a/tests/test_core_models.py
+++ b/tests/test_core_models.py
@@ -1,0 +1,11 @@
+from core.models import TimestampedModel
+
+
+def test_timestamped_model_is_abstract() -> None:
+    assert TimestampedModel._meta.abstract is True
+
+
+def test_timestamped_model_has_auto_timestamp_fields() -> None:
+    fields = {f.name: f for f in TimestampedModel._meta.get_fields()}
+    assert fields["created_at"].auto_now_add is True  # type: ignore[attr-defined]
+    assert fields["updated_at"].auto_now is True  # type: ignore[attr-defined]

--- a/tests/test_ids.py
+++ b/tests/test_ids.py
@@ -1,0 +1,7 @@
+from core.utils.ids import uuid7
+
+
+def test_uuid7_is_monotonic() -> None:
+    a = uuid7()
+    b = uuid7()
+    assert a.bytes < b.bytes


### PR DESCRIPTION
## Summary
- `core/models.py`: `TimestampedModel` abstract base with `created_at` / `updated_at` (`auto_now_add` / `auto_now`).
- `core/utils/ids.py`: re-exports stdlib `uuid.uuid7` (Python 3.14, RFC 9562) so models can do `UUIDField(default=uuid7)`. A project-controlled import surface lets us swap the strategy in one file later.
- Tests cover the abstract-meta flag, the auto-timestamp field flags, and `uuid7` monotonic ordering.

No migration: `Meta.abstract = True` and `manage.py makemigrations --check` is a no-op.

Closes #2.

## Test plan
- [x] `uv run ruff check core tests` - clean
- [x] `uv run ruff format --check core tests` - clean
- [x] `uv run pyright` - 0 errors
- [x] `uv run pytest -q` - 4 passed (1 pre-existing smoke + 3 new)
- [x] `uv run python manage.py makemigrations --check --dry-run` - no migration proposed

🤖 Generated with [Claude Code](https://claude.com/claude-code)