### PR TITLE
Add TenantOwnedManager and tenant-lint CI guardrail

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,35 @@
+name: CI
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+          python-version: "3.14"
+
+      - name: Sync deps
+        run: uv sync --all-extras --dev
+
+      - name: ruff check
+        run: uv run ruff check .
+
+      - name: ruff format
+        run: uv run ruff format --check .
+
+      - name: pyright
+        run: uv run pyright
+
+      - name: tenant-lint
+        run: uv run python scripts/tenant_lint.py
+
+      - name: pytest
+        run: uv run pytest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,4 +32,6 @@ jobs:
         run: uv run python scripts/tenant_lint.py
 
       - name: pytest
+        env:
+          DJANGO_SECRET_KEY: ci-not-a-secret
         run: uv run pytest

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,3 +12,11 @@ repos:
       - id: end-of-file-fixer
       - id: check-yaml
       - id: check-added-large-files
+  - repo: local
+    hooks:
+      - id: tenant-lint
+        name: Block raw .objects in viewsets
+        language: system
+        entry: python scripts/tenant_lint.py
+        files: '(^|/)(views|viewsets)(\.py$|/[^/]+\.py$)'
+        pass_filenames: true

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,50 @@
+# Contributing
+
+## Setup
+
+```sh
+uv sync
+uv run pre-commit install
+```
+
+## Tenant scoping rule
+
+Tenant-owned models must be queried in views/viewsets via the
+`TenantOwnedManager` helpers, not raw `.objects`:
+
+```python
+# good
+qs = Order.tenant_objects.for_request(self.request)
+qs = Order.tenant_objects.for_organization(org)
+
+# bad — bypasses tenant scoping
+qs = Order.objects.all()
+qs = Order.objects.filter(...)
+qs = Order.objects.get(...)
+```
+
+`scripts/tenant_lint.py` runs in CI and as a `pre-commit` hook. It
+rejects `.objects.{all,filter,get}(` in any file matching
+`**/views.py`, `**/viewsets.py`, `**/views/*.py`, or
+`**/viewsets/*.py`.
+
+### Escape hatch
+
+For non-tenant models or intentional system-level access, append
+`# noqa: tenant-lint` to the offending line. Prefer
+`Model._default_manager` over `.objects` when bypassing scoping
+deliberately.
+
+```python
+SiteConfig.objects.get(pk=1)  # noqa: tenant-lint
+```
+
+## Running checks locally
+
+```sh
+uv run ruff check .
+uv run ruff format --check .
+uv run pyright
+uv run python scripts/tenant_lint.py
+uv run pytest
+```

--- a/core/managers.py
+++ b/core/managers.py
@@ -27,9 +27,7 @@ from core.models import Organization
 class TenantOwnedManager(models.Manager):
     organization_lookup: str = "organization"
 
-    def for_organization(
-        self, organization: Organization
-    ) -> models.QuerySet:
+    def for_organization(self, organization: Organization) -> models.QuerySet:
         return self.get_queryset().filter(
             **{self.organization_lookup: organization}
         )

--- a/core/managers.py
+++ b/core/managers.py
@@ -1,0 +1,38 @@
+"""Shared managers for tenant-scoped models.
+
+`TenantOwnedManager` provides two methods:
+
+- `for_organization(org)`: primitive used by tasks, management commands,
+  admin, and tests. Filters on the model's path to `Organization`.
+- `for_request(request)`: thin wrapper used by views; delegates to
+  `for_organization(request.organization)`. Assumes the tenant middleware
+  has populated `request.organization`.
+
+Default `.objects` stays unscoped (Django convention). Models attach this
+manager under a separate name (e.g. `tenant_objects`) when they pick it up.
+
+For models where `Organization` is reached via a related field, override
+`organization_lookup` on the subclass:
+
+    class LocationMembershipManager(TenantOwnedManager):
+        organization_lookup = "location__organization"
+"""
+
+from django.db import models
+from django.http import HttpRequest
+
+from core.models import Organization
+
+
+class TenantOwnedManager(models.Manager):
+    organization_lookup: str = "organization"
+
+    def for_organization(
+        self, organization: Organization
+    ) -> models.QuerySet:
+        return self.get_queryset().filter(
+            **{self.organization_lookup: organization}
+        )
+
+    def for_request(self, request: HttpRequest) -> models.QuerySet:
+        return self.for_organization(request.organization)  # type: ignore[attr-defined]

--- a/core/models/user.py
+++ b/core/models/user.py
@@ -45,9 +45,7 @@ class UserManager(BaseUserManager["User"]):
         if extra_fields.get("is_staff") is not True:
             raise ValueError(_("Superuser must have is_staff=True."))
         if extra_fields.get("is_superuser") is not True:
-            raise ValueError(
-                _("Superuser must have is_superuser=True.")
-            )
+            raise ValueError(_("Superuser must have is_superuser=True."))
         return self.create_user(email, password, **extra_fields)
 
 

--- a/scripts/tenant_lint.py
+++ b/scripts/tenant_lint.py
@@ -1,0 +1,70 @@
+"""Block raw `.objects.{all,filter,get}` in view layers.
+
+Tenant-scoped models must be queried via `TenantOwnedManager.for_request`
+or `for_organization`. Direct manager use in views/viewsets bypasses
+tenant scoping. See CONTRIBUTING.md.
+
+Per-line escape hatch: append `# noqa: tenant-lint`.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+PATH_RE = re.compile(r"(^|/)(views|viewsets)(\.py$|/[^/]+\.py$)")
+BAD_RE = re.compile(r"\.objects\.(all|filter|get)\s*\(")
+SKIP = "# noqa: tenant-lint"
+EXCLUDE_DIRS = {".venv", "migrations", "__pycache__", ".git", "node_modules"}
+
+
+def iter_default_files() -> list[Path]:
+    root = Path(__file__).resolve().parent.parent
+    out: list[Path] = []
+    for p in root.rglob("*.py"):
+        if any(part in EXCLUDE_DIRS for part in p.relative_to(root).parts):
+            continue
+        if PATH_RE.search(p.relative_to(root).as_posix()):
+            out.append(p)
+    return out
+
+
+def check(paths: list[Path]) -> list[tuple[Path, int, str]]:
+    hits: list[tuple[Path, int, str]] = []
+    for path in paths:
+        if not PATH_RE.search(path.as_posix()):
+            continue
+        try:
+            text = path.read_text(encoding="utf-8")
+        except OSError:
+            continue
+        for lineno, line in enumerate(text.splitlines(), start=1):
+            if SKIP in line:
+                continue
+            if BAD_RE.search(line):
+                hits.append((path, lineno, line.strip()))
+    return hits
+
+
+def main(argv: list[str]) -> int:
+    if argv:
+        paths = [Path(a) for a in argv]
+    else:
+        paths = iter_default_files()
+    hits = check(paths)
+    if not hits:
+        return 0
+    for path, lineno, src in hits:
+        print(f"{path}:{lineno}: {src}", file=sys.stderr)
+    print(
+        "\ntenant-lint: use `.for_request(self.request)` or "
+        "`.for_organization(org)` instead of raw `.objects.{all,filter,get}` "
+        "in views/viewsets. Append `# noqa: tenant-lint` to opt out.",
+        file=sys.stderr,
+    )
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/scripts/tenant_lint.py
+++ b/scripts/tenant_lint.py
@@ -48,10 +48,7 @@ def check(paths: list[Path]) -> list[tuple[Path, int, str]]:
 
 
 def main(argv: list[str]) -> int:
-    if argv:
-        paths = [Path(a) for a in argv]
-    else:
-        paths = iter_default_files()
+    paths = [Path(a) for a in argv] if argv else iter_default_files()
     hits = check(paths)
     if not hits:
         return 0

--- a/tests/test_core_managers.py
+++ b/tests/test_core_managers.py
@@ -1,0 +1,65 @@
+from types import SimpleNamespace
+
+import pytest
+
+from core.managers import TenantOwnedManager
+from core.models import Location, LocationMembership
+
+from tests.factories import (
+    LocationFactory,
+    LocationMembershipFactory,
+    OrganizationFactory,
+)
+
+
+class _LocationMembershipTenantManager(TenantOwnedManager):
+    organization_lookup = "location__organization"
+
+
+TenantOwnedManager().contribute_to_class(Location, "tenant_objects")
+_LocationMembershipTenantManager().contribute_to_class(
+    LocationMembership, "tenant_objects"
+)
+
+
+@pytest.mark.django_db
+def test_for_organization_direct_path() -> None:
+    org_a = OrganizationFactory()
+    org_b = OrganizationFactory()
+    a1 = LocationFactory(organization=org_a)
+    a2 = LocationFactory(organization=org_a)
+    LocationFactory(organization=org_b)
+
+    qs = Location.tenant_objects.for_organization(org_a)  # type: ignore[attr-defined]
+
+    assert set(qs) == {a1, a2}
+
+
+@pytest.mark.django_db
+def test_for_organization_indirect_path() -> None:
+    org_a = OrganizationFactory()
+    org_b = OrganizationFactory()
+    loc_a = LocationFactory(organization=org_a)
+    loc_b = LocationFactory(organization=org_b)
+    m1 = LocationMembershipFactory(location=loc_a)
+    m2 = LocationMembershipFactory(location=loc_a)
+    LocationMembershipFactory(location=loc_b)
+
+    qs = LocationMembership.tenant_objects.for_organization(org_a)  # type: ignore[attr-defined]
+
+    assert set(qs) == {m1, m2}
+
+
+@pytest.mark.django_db
+def test_for_request_delegates_to_for_organization() -> None:
+    org_a = OrganizationFactory()
+    org_b = OrganizationFactory()
+    LocationFactory(organization=org_a)
+    LocationFactory(organization=org_b)
+
+    request = SimpleNamespace(organization=org_a)
+
+    direct = Location.tenant_objects.for_organization(org_a)  # type: ignore[attr-defined]
+    via_request = Location.tenant_objects.for_request(request)  # type: ignore[attr-defined]
+
+    assert list(via_request) == list(direct)

--- a/tests/test_core_managers.py
+++ b/tests/test_core_managers.py
@@ -4,7 +4,6 @@ import pytest
 
 from core.managers import TenantOwnedManager
 from core.models import Location, LocationMembership
-
 from tests.factories import (
     LocationFactory,
     LocationMembershipFactory,

--- a/tests/test_core_membership.py
+++ b/tests/test_core_membership.py
@@ -89,6 +89,4 @@ def test_created_by_protect() -> None:
 def test_related_names() -> None:
     m = OrganizationMembershipFactory()
     assert m.user.organization_memberships.filter(pk=m.pk).exists()
-    assert m.organization.organization_memberships.filter(
-        pk=m.pk
-    ).exists()
+    assert m.organization.organization_memberships.filter(pk=m.pk).exists()

--- a/tests/test_core_models.py
+++ b/tests/test_core_models.py
@@ -227,5 +227,3 @@ def test_vat_validator_rejects_nl_for_be_org() -> None:
     )
     with pytest.raises(ValidationError):
         org.full_clean()
-
-

--- a/tests/test_core_user.py
+++ b/tests/test_core_user.py
@@ -87,9 +87,7 @@ def test_user_inherits_timestamps() -> None:
 
 @pytest.mark.django_db
 def test_create_superuser_sets_flags() -> None:
-    user = User.objects.create_superuser(
-        email="a@example.be", password="pw"
-    )
+    user = User.objects.create_superuser(email="a@example.be", password="pw")
     assert user.is_staff is True
     assert user.is_superuser is True
     assert user.is_active is True


### PR DESCRIPTION
## Summary
- Add `core/managers.py:TenantOwnedManager` with `for_organization(org)` and `for_request(request)`; default `.objects` stays unscoped. Subclasses override `organization_lookup` for indirect FK paths.
- Add `scripts/tenant_lint.py` blocking raw `.objects.{all,filter,get}(` in `views.py` / `viewsets.py` (and `views/` / `viewsets/` packages). Per-line escape hatch via `# noqa: tenant-lint`.
- Stand up `.github/workflows/ci.yml` running ruff, ruff-format, pyright, tenant-lint, pytest. Wire the same lint as a local `pre-commit` hook.
- Document the rule and escape hatch in `CONTRIBUTING.md`.

Closes #8
Closes #9

## Test plan
- [ ] `uv run pytest tests/test_core_managers.py` passes (org isolation asserted)
- [ ] `uv run python scripts/tenant_lint.py` exits 0 on a clean tree
- [ ] Adding `Organization.objects.all()` to a `views.py` -> tenant-lint exits 1, line reported
- [ ] Same line with trailing `# noqa: tenant-lint` -> exits 0
- [ ] `uv run pre-commit run tenant-lint --all-files` mirrors script exit code
- [ ] CI workflow runs all steps green on this PR