### PR TITLE
Add TenantMiddleware for /o/<slug>/ resolution

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -37,6 +37,7 @@ MIDDLEWARE = [
     "django.middleware.common.CommonMiddleware",
     "django.middleware.csrf.CsrfViewMiddleware",
     "django.contrib.auth.middleware.AuthenticationMiddleware",
+    "core.middleware.TenantMiddleware",
     "django.contrib.messages.middleware.MessageMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
     "django_htmx.middleware.HtmxMiddleware",

--- a/core/middleware.py
+++ b/core/middleware.py
@@ -1,0 +1,43 @@
+import re
+from collections.abc import Callable
+
+from django.http import Http404, HttpRequest, HttpResponse
+
+from core.models import Organization
+
+_TENANT_PATH_RE = re.compile(r"^/o/(?P<slug>[a-z0-9-]+)/")
+
+
+class TenantMiddleware:
+    def __init__(
+        self,
+        get_response: Callable[[HttpRequest], HttpResponse],
+    ) -> None:
+        self.get_response = get_response
+
+    def __call__(self, request: HttpRequest) -> HttpResponse:
+        request.organization = None  # type: ignore[attr-defined]
+        match = _TENANT_PATH_RE.match(request.path)
+        if match is None:
+            return self.get_response(request)
+
+        slug = match["slug"]
+        user = request.user
+
+        if user.is_authenticated and user.is_superuser:
+            org = Organization.objects.filter(slug=slug, is_active=True).first()
+        elif user.is_authenticated:
+            org = Organization.objects.filter(
+                slug=slug,
+                is_active=True,
+                organization_memberships__user=user,
+                organization_memberships__is_active=True,
+            ).first()
+        else:
+            org = None
+
+        if org is None:
+            raise Http404
+
+        request.organization = org  # type: ignore[attr-defined]
+        return self.get_response(request)

--- a/tests/test_core_middleware.py
+++ b/tests/test_core_middleware.py
@@ -1,0 +1,123 @@
+import pytest
+from django.contrib.auth.models import AnonymousUser
+from django.core.handlers.wsgi import WSGIRequest
+from django.http import Http404, HttpResponse
+from django.test import RequestFactory
+
+from core.middleware import TenantMiddleware
+from core.models import User
+from tests.factories import (
+    OrganizationFactory,
+    OrganizationMembershipFactory,
+    UserFactory,
+)
+
+SENTINEL = HttpResponse("ok")
+
+
+def _get_response(request: WSGIRequest) -> HttpResponse:
+    request._view_called = True  # type: ignore[attr-defined]
+    return SENTINEL
+
+
+def _call(
+    path: str, user: User | AnonymousUser
+) -> tuple[HttpResponse, WSGIRequest]:
+    rf = RequestFactory()
+    request = rf.get(path)
+    request.user = user
+    mw = TenantMiddleware(_get_response)
+    response = mw(request)
+    return response, request
+
+
+@pytest.mark.parametrize("path", ["/", "/login/", "/admin/", "/o/", "/o/Foo/"])
+def test_non_tenant_paths_pass_through(path: str) -> None:
+    response, request = _call(path, AnonymousUser())
+    assert response is SENTINEL
+    assert request.organization is None
+    assert getattr(request, "_view_called", False) is True
+
+
+@pytest.mark.django_db
+def test_anonymous_existing_org_returns_404() -> None:
+    org = OrganizationFactory()
+    with pytest.raises(Http404):
+        _call(f"/o/{org.slug}/", AnonymousUser())
+
+
+def test_anonymous_missing_org_returns_404() -> None:
+    with pytest.raises(Http404):
+        _call("/o/does-not-exist/", AnonymousUser())
+
+
+@pytest.mark.django_db
+def test_authed_no_membership_returns_404() -> None:
+    org = OrganizationFactory()
+    user = UserFactory()
+    with pytest.raises(Http404):
+        _call(f"/o/{org.slug}/", user)
+
+
+@pytest.mark.django_db
+def test_authed_inactive_membership_returns_404() -> None:
+    membership = OrganizationMembershipFactory(is_active=False)
+    with pytest.raises(Http404):
+        _call(f"/o/{membership.organization.slug}/", membership.user)
+
+
+@pytest.mark.django_db
+def test_authed_membership_on_other_org_returns_404() -> None:
+    membership = OrganizationMembershipFactory()
+    other = OrganizationFactory()
+    with pytest.raises(Http404):
+        _call(f"/o/{other.slug}/", membership.user)
+
+
+@pytest.mark.django_db
+def test_authed_active_membership_resolves_org() -> None:
+    membership = OrganizationMembershipFactory()
+    path = f"/o/{membership.organization.slug}/"
+    response, request = _call(path, membership.user)
+    assert response is SENTINEL
+    assert request.organization == membership.organization
+
+
+@pytest.mark.django_db
+def test_authed_inactive_org_returns_404() -> None:
+    membership = OrganizationMembershipFactory(organization__is_active=False)
+    with pytest.raises(Http404):
+        _call(f"/o/{membership.organization.slug}/", membership.user)
+
+
+@pytest.mark.django_db
+def test_superuser_resolves_existing_org_without_membership() -> None:
+    org = OrganizationFactory()
+    user = UserFactory(is_superuser=True, is_staff=True)
+    response, request = _call(f"/o/{org.slug}/", user)
+    assert response is SENTINEL
+    assert request.organization == org
+
+
+@pytest.mark.django_db
+def test_superuser_missing_org_returns_404() -> None:
+    user = UserFactory(is_superuser=True, is_staff=True)
+    with pytest.raises(Http404):
+        _call("/o/does-not-exist/", user)
+
+
+@pytest.mark.django_db
+def test_superuser_inactive_org_returns_404() -> None:
+    org = OrganizationFactory(is_active=False)
+    user = UserFactory(is_superuser=True, is_staff=True)
+    with pytest.raises(Http404):
+        _call(f"/o/{org.slug}/", user)
+
+
+@pytest.mark.django_db
+def test_nested_path_resolves_org() -> None:
+    membership = OrganizationMembershipFactory()
+    path = f"/o/{membership.organization.slug}/locations/abc/edit/"
+    response, request = _call(path, membership.user)
+    assert response is SENTINEL
+    assert request.organization == membership.organization


### PR DESCRIPTION
Closes #10.

## Summary
- Add `core/middleware.py:TenantMiddleware`. Parses `/o/<slug>/...` from `request.path`, resolves to an active `Organization` exposed as `request.organization`, gated by an active `OrganizationMembership` (or `is_superuser`). `None` for non-tenant URLs.
- Wire into `MIDDLEWARE` in `config/settings/base.py` immediately after `AuthenticationMiddleware`.
- 16 unit tests in `tests/test_core_middleware.py` covering pass-through, anon, missing/inactive org, no/inactive/cross-org membership, active-membership resolve, superuser bypass, superuser missing/inactive org, nested paths, malformed slugs.

## Deviation from issue acceptance criteria
The issue AC says "Anonymous request to `/o/<slug>/` -> redirect to login (or 404 if org doesn't exist)". This PR returns **404 in both cases** (anon + existing org also 404s), matching whitepaper §4 ("avoid leaking org existence"). Redirecting only when the org exists would let an unauthenticated attacker enumerate org slugs by observing redirect vs 404. Login-redirect handling lives in EPIC #2 anyway; the middleware stays purely a gate.

## Implementation note
The authed-non-superuser path uses a single query joining `Organization` to `organization_memberships` via the reverse relation, so org-existence and membership-existence collapse into one branch. Avoids timing/codepath signal between "org missing" and "no membership".

## Test plan
- [x] `uv run pytest` -> 87 passed
- [x] `uv run ruff check` + `ruff format --check` clean
- [x] `uv run pyright` clean