### PR TITLE
Add core/services layer: membership invariants + atomic org signup

### DIFF
--- a/core/services/exceptions.py
+++ b/core/services/exceptions.py
@@ -1,0 +1,15 @@
+from collections.abc import Sequence
+
+from core.models import Organization
+
+
+class LastActiveAdminError(Exception):
+    """Operation would leave one or more orgs without a qualifying ADMIN."""
+
+    def __init__(self, organizations: Sequence[Organization]) -> None:
+        self.organizations: list[Organization] = list(organizations)
+        slugs = ", ".join(o.slug for o in self.organizations)
+        super().__init__(
+            f"Operation would leave organization(s) without an active "
+            f"ADMIN: {slugs}"
+        )

--- a/core/services/membership.py
+++ b/core/services/membership.py
@@ -1,0 +1,124 @@
+from django.db import transaction
+
+from core.models import Organization, OrganizationMembership, Role, User
+from core.services.exceptions import LastActiveAdminError
+
+
+def _other_qualifying_admin_exists(
+    organization: Organization,
+    *,
+    exclude_membership: OrganizationMembership | None = None,
+    exclude_user: User | None = None,
+) -> bool:
+    qs = OrganizationMembership.objects.filter(
+        organization=organization,
+        role=Role.ADMIN,
+        is_active=True,
+        user__is_active=True,
+    )
+    if exclude_membership is not None:
+        qs = qs.exclude(pk=exclude_membership.pk)
+    if exclude_user is not None:
+        qs = qs.exclude(user=exclude_user)
+    return qs.exists()
+
+
+def deactivate_membership(membership: OrganizationMembership) -> None:
+    if not membership.is_active:
+        return
+    with transaction.atomic():
+        # Lock the org row first so concurrent admin-changing writes on
+        # this org serialize on it (prevents the AB-BA race where two
+        # co-admins demote each other and both pass the invariant check).
+        Organization.objects.select_for_update().get(
+            pk=membership.organization.pk
+        )
+        locked = (
+            OrganizationMembership.objects.select_for_update()
+            .select_related("organization")
+            .get(pk=membership.pk)
+        )
+        if not locked.is_active:
+            return
+        is_qualifying = locked.role == Role.ADMIN and locked.user.is_active
+        if is_qualifying and not _other_qualifying_admin_exists(
+            locked.organization, exclude_membership=locked
+        ):
+            raise LastActiveAdminError([locked.organization])
+        locked.is_active = False
+        locked.save(update_fields=["is_active", "updated_at"])
+        membership.is_active = False
+        membership.updated_at = locked.updated_at
+
+
+def change_role(
+    membership: OrganizationMembership, new_role: Role | str
+) -> None:
+    if new_role not in Role.values:
+        raise ValueError(f"Unknown role: {new_role!r}")
+    if membership.role == new_role:
+        return
+    with transaction.atomic():
+        Organization.objects.select_for_update().get(
+            pk=membership.organization.pk
+        )
+        locked = (
+            OrganizationMembership.objects.select_for_update()
+            .select_related("organization")
+            .get(pk=membership.pk)
+        )
+        if locked.role == new_role:
+            return
+        demoting_qualifier = (
+            locked.role == Role.ADMIN
+            and new_role != Role.ADMIN
+            and locked.is_active
+            and locked.user.is_active
+        )
+        if demoting_qualifier and not _other_qualifying_admin_exists(
+            locked.organization, exclude_membership=locked
+        ):
+            raise LastActiveAdminError([locked.organization])
+        locked.role = new_role
+        locked.save(update_fields=["role", "updated_at"])
+        membership.role = new_role
+        membership.updated_at = locked.updated_at
+
+
+def deactivate_user(user: User) -> None:
+    if not user.is_active:
+        return
+    with transaction.atomic():
+        locked_user = User.objects.select_for_update().get(pk=user.pk)
+        if not locked_user.is_active:
+            return
+        admin_memberships = list(
+            OrganizationMembership.objects.select_related("organization")
+            .filter(user=locked_user, role=Role.ADMIN, is_active=True)
+            .order_by("organization_id")
+        )
+        if admin_memberships:
+            org_ids = [m.organization.pk for m in admin_memberships]
+            # Lock all involved org rows in pk order to avoid deadlocks
+            # against concurrent invariant-affecting writes on those orgs.
+            list(
+                Organization.objects.select_for_update()
+                .filter(pk__in=org_ids)
+                .order_by("pk")
+            )
+            offending = sorted(
+                (
+                    m.organization
+                    for m in admin_memberships
+                    if not _other_qualifying_admin_exists(
+                        m.organization, exclude_user=locked_user
+                    )
+                ),
+                key=lambda o: o.slug,
+            )
+            if offending:
+                raise LastActiveAdminError(offending)
+        locked_user.is_active = False
+        locked_user.save(update_fields=["is_active", "updated_at"])
+        user.is_active = False
+        user.updated_at = locked_user.updated_at

--- a/core/services/signup.py
+++ b/core/services/signup.py
@@ -1,0 +1,39 @@
+from django.db import transaction
+
+from core.models import Organization, OrganizationMembership, Role, User
+
+
+def create_organization_with_admin(
+    *,
+    email: str,
+    password: str,
+    org_name: str,
+    org_slug: str,
+    vat_number: str,
+    billing_email: str,
+    country: str = "BE",
+) -> tuple[Organization, User, OrganizationMembership]:
+    with transaction.atomic():
+        org = Organization(
+            name=org_name,
+            slug=org_slug,
+            vat_number=vat_number,
+            billing_email=billing_email,
+            country=country,
+            is_active=False,
+        )
+        # Run slug regex + VAT/country invariant. Skip uniqueness so
+        # duplicate slug/email surface as IntegrityError per issue #14.
+        org.full_clean(validate_unique=False)
+        org.save()
+        user = User.objects.create_user(
+            email=email, password=password, is_active=False
+        )
+        membership = OrganizationMembership.objects.create(
+            user=user,
+            organization=org,
+            role=Role.ADMIN,
+            is_active=True,
+            created_by=None,
+        )
+        return org, user, membership

--- a/tests/test_core_services_membership.py
+++ b/tests/test_core_services_membership.py
@@ -1,0 +1,280 @@
+import pytest
+from django.db import connection
+from django.test.utils import CaptureQueriesContext
+
+from core.models import OrganizationMembership, Role
+from core.services.exceptions import LastActiveAdminError
+from core.services.membership import (
+    change_role,
+    deactivate_membership,
+    deactivate_user,
+)
+from tests.factories import (
+    OrganizationFactory,
+    OrganizationMembershipFactory,
+    UserFactory,
+)
+
+# ---- deactivate_membership -------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_deactivate_membership_succeeds_for_operator() -> None:
+    m = OrganizationMembershipFactory(role=Role.OPERATOR)
+    deactivate_membership(m)
+    m.refresh_from_db()
+    assert m.is_active is False
+
+
+@pytest.mark.django_db
+def test_deactivate_membership_succeeds_for_non_last_admin() -> None:
+    org = OrganizationFactory()
+    m1 = OrganizationMembershipFactory(organization=org, role=Role.ADMIN)
+    OrganizationMembershipFactory(organization=org, role=Role.ADMIN)
+    deactivate_membership(m1)
+    m1.refresh_from_db()
+    assert m1.is_active is False
+
+
+@pytest.mark.django_db
+def test_deactivate_membership_raises_for_last_admin() -> None:
+    org = OrganizationFactory()
+    m = OrganizationMembershipFactory(organization=org, role=Role.ADMIN)
+    with pytest.raises(LastActiveAdminError) as exc:
+        deactivate_membership(m)
+    assert exc.value.organizations == [org]
+    m.refresh_from_db()
+    assert m.is_active is True
+
+
+@pytest.mark.django_db
+def test_deactivate_membership_idempotent_on_already_inactive() -> None:
+    m = OrganizationMembershipFactory(role=Role.OPERATOR, is_active=False)
+    before = m.updated_at
+    deactivate_membership(m)
+    m.refresh_from_db()
+    assert m.is_active is False
+    assert m.updated_at == before
+
+
+@pytest.mark.django_db
+def test_deactivate_membership_inactive_user_admin_does_not_count() -> None:
+    org = OrganizationFactory()
+    inactive = UserFactory(is_active=False)
+    OrganizationMembershipFactory(
+        user=inactive, organization=org, role=Role.ADMIN
+    )
+    sole_qualifying = OrganizationMembershipFactory(
+        organization=org, role=Role.ADMIN
+    )
+    with pytest.raises(LastActiveAdminError):
+        deactivate_membership(sole_qualifying)
+
+
+@pytest.mark.django_db
+def test_deactivate_membership_when_self_user_inactive_succeeds() -> None:
+    org = OrganizationFactory()
+    inactive = UserFactory(is_active=False)
+    m = OrganizationMembershipFactory(
+        user=inactive, organization=org, role=Role.ADMIN
+    )
+    deactivate_membership(m)
+    m.refresh_from_db()
+    assert m.is_active is False
+
+
+@pytest.mark.django_db
+def test_deactivate_membership_does_not_affect_other_orgs() -> None:
+    user = UserFactory()
+    org_a = OrganizationFactory()
+    org_b = OrganizationFactory()
+    OrganizationMembershipFactory(organization=org_a, role=Role.ADMIN)
+    OrganizationMembershipFactory(organization=org_b, role=Role.ADMIN)
+    m_a = OrganizationMembershipFactory(
+        user=user, organization=org_a, role=Role.ADMIN
+    )
+    m_b = OrganizationMembershipFactory(
+        user=user, organization=org_b, role=Role.ADMIN
+    )
+    deactivate_membership(m_a)
+    m_a.refresh_from_db()
+    m_b.refresh_from_db()
+    assert m_a.is_active is False
+    assert m_b.is_active is True
+
+
+# ---- change_role -----------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_change_role_promotes_operator_to_admin() -> None:
+    m = OrganizationMembershipFactory(role=Role.OPERATOR)
+    change_role(m, Role.ADMIN)
+    m.refresh_from_db()
+    assert m.role == Role.ADMIN
+
+
+@pytest.mark.django_db
+def test_change_role_demotes_non_last_admin() -> None:
+    org = OrganizationFactory()
+    m = OrganizationMembershipFactory(organization=org, role=Role.ADMIN)
+    OrganizationMembershipFactory(organization=org, role=Role.ADMIN)
+    change_role(m, Role.OPERATOR)
+    m.refresh_from_db()
+    assert m.role == Role.OPERATOR
+
+
+@pytest.mark.django_db
+def test_change_role_demoting_last_admin_raises() -> None:
+    org = OrganizationFactory()
+    m = OrganizationMembershipFactory(organization=org, role=Role.ADMIN)
+    with pytest.raises(LastActiveAdminError) as exc:
+        change_role(m, Role.OPERATOR)
+    assert exc.value.organizations == [org]
+    m.refresh_from_db()
+    assert m.role == Role.ADMIN
+
+
+@pytest.mark.django_db
+def test_change_role_same_role_is_noop() -> None:
+    m = OrganizationMembershipFactory(role=Role.ADMIN)
+    before = m.updated_at
+    with CaptureQueriesContext(connection) as ctx:
+        change_role(m, Role.ADMIN)
+    assert len(ctx.captured_queries) == 0
+    m.refresh_from_db()
+    assert m.updated_at == before
+
+
+@pytest.mark.django_db
+def test_change_role_unknown_role_raises_value_error() -> None:
+    m = OrganizationMembershipFactory(role=Role.ADMIN)
+    with pytest.raises(ValueError, match="Unknown role"):
+        change_role(m, "WIZARD")
+    m.refresh_from_db()
+    assert m.role == Role.ADMIN
+
+
+@pytest.mark.django_db
+def test_change_role_demoting_inactive_admin_succeeds() -> None:
+    org = OrganizationFactory()
+    m = OrganizationMembershipFactory(
+        organization=org, role=Role.ADMIN, is_active=False
+    )
+    change_role(m, Role.OPERATOR)
+    m.refresh_from_db()
+    assert m.role == Role.OPERATOR
+
+
+@pytest.mark.django_db
+def test_change_role_demoting_admin_with_inactive_user_succeeds() -> None:
+    org = OrganizationFactory()
+    inactive = UserFactory(is_active=False)
+    m = OrganizationMembershipFactory(
+        user=inactive, organization=org, role=Role.ADMIN
+    )
+    change_role(m, Role.OPERATOR)
+    m.refresh_from_db()
+    assert m.role == Role.OPERATOR
+
+
+# ---- deactivate_user -------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_deactivate_user_idempotent_on_already_inactive() -> None:
+    user = UserFactory(is_active=False)
+    before = user.updated_at
+    deactivate_user(user)
+    user.refresh_from_db()
+    assert user.is_active is False
+    assert user.updated_at == before
+
+
+@pytest.mark.django_db
+def test_deactivate_user_with_no_memberships_succeeds() -> None:
+    user = UserFactory()
+    deactivate_user(user)
+    user.refresh_from_db()
+    assert user.is_active is False
+
+
+@pytest.mark.django_db
+def test_deactivate_user_with_only_operator_memberships_succeeds() -> None:
+    user = UserFactory()
+    OrganizationMembershipFactory(user=user, role=Role.OPERATOR)
+    OrganizationMembershipFactory(user=user, role=Role.OPERATOR)
+    deactivate_user(user)
+    user.refresh_from_db()
+    assert user.is_active is False
+
+
+@pytest.mark.django_db
+def test_deactivate_user_as_co_admin_succeeds() -> None:
+    org = OrganizationFactory()
+    user = UserFactory()
+    OrganizationMembershipFactory(user=user, organization=org, role=Role.ADMIN)
+    OrganizationMembershipFactory(organization=org, role=Role.ADMIN)
+    deactivate_user(user)
+    user.refresh_from_db()
+    assert user.is_active is False
+
+
+@pytest.mark.django_db
+def test_deactivate_user_as_sole_admin_raises() -> None:
+    org = OrganizationFactory()
+    user = UserFactory()
+    OrganizationMembershipFactory(user=user, organization=org, role=Role.ADMIN)
+    with pytest.raises(LastActiveAdminError) as exc:
+        deactivate_user(user)
+    assert exc.value.organizations == [org]
+    user.refresh_from_db()
+    assert user.is_active is True
+
+
+@pytest.mark.django_db
+def test_deactivate_user_aggregates_multiple_offending_orgs() -> None:
+    user = UserFactory()
+    org_a = OrganizationFactory(slug="aaa")
+    org_b = OrganizationFactory(slug="bbb")
+    OrganizationMembershipFactory(
+        user=user, organization=org_a, role=Role.ADMIN
+    )
+    OrganizationMembershipFactory(
+        user=user, organization=org_b, role=Role.ADMIN
+    )
+    with pytest.raises(LastActiveAdminError) as exc:
+        deactivate_user(user)
+    assert [o.slug for o in exc.value.organizations] == ["aaa", "bbb"]
+    user.refresh_from_db()
+    assert user.is_active is True
+
+
+@pytest.mark.django_db
+def test_deactivate_user_inactive_admin_membership_excluded() -> None:
+    user = UserFactory()
+    org = OrganizationFactory()
+    OrganizationMembershipFactory(organization=org, role=Role.ADMIN)
+    OrganizationMembershipFactory(
+        user=user, organization=org, role=Role.ADMIN, is_active=False
+    )
+    deactivate_user(user)
+    user.refresh_from_db()
+    assert user.is_active is False
+
+
+@pytest.mark.django_db
+def test_deactivate_user_does_not_modify_memberships() -> None:
+    user = UserFactory()
+    org = OrganizationFactory()
+    OrganizationMembershipFactory(organization=org, role=Role.ADMIN)
+    m_admin = OrganizationMembershipFactory(
+        user=user, organization=org, role=Role.ADMIN
+    )
+    m_op = OrganizationMembershipFactory(user=user, role=Role.OPERATOR)
+    deactivate_user(user)
+    m_admin.refresh_from_db()
+    m_op.refresh_from_db()
+    assert m_admin.is_active is True
+    assert m_op.is_active is True
+    assert OrganizationMembership.objects.filter(user=user).count() == 2

--- a/tests/test_core_services_signup.py
+++ b/tests/test_core_services_signup.py
@@ -1,0 +1,135 @@
+import pytest
+from django.core.exceptions import ValidationError
+from django.db import IntegrityError
+
+from core.models import Organization, OrganizationMembership, Role, User
+from core.services.signup import create_organization_with_admin
+
+
+@pytest.mark.django_db
+def test_creates_all_three_rows() -> None:
+    org, user, mem = create_organization_with_admin(
+        email="o@x.be",
+        password="hunter22",
+        org_name="X",
+        org_slug="x",
+        vat_number="BE0417710407",
+        billing_email="b@x.be",
+    )
+    assert org.is_active is False
+    assert user.is_active is False
+    assert mem.role == Role.ADMIN
+    assert mem.is_active is True
+    assert mem.created_by is None
+    assert user.check_password("hunter22")
+
+
+@pytest.mark.django_db
+def test_normalizes_email_to_lowercase() -> None:
+    _, user, _ = create_organization_with_admin(
+        email="Foo@Example.BE",
+        password="hunter22",
+        org_name="X",
+        org_slug="x",
+        vat_number="BE0417710407",
+        billing_email="b@x.be",
+    )
+    assert user.email == "foo@example.be"
+
+
+@pytest.mark.django_db
+def test_returns_three_tuple_of_correct_types() -> None:
+    result = create_organization_with_admin(
+        email="o@x.be",
+        password="hunter22",
+        org_name="X",
+        org_slug="x",
+        vat_number="BE0417710407",
+        billing_email="b@x.be",
+    )
+    assert isinstance(result, tuple)
+    assert len(result) == 3
+    assert isinstance(result[0], Organization)
+    assert isinstance(result[1], User)
+    assert isinstance(result[2], OrganizationMembership)
+
+
+@pytest.mark.django_db
+def test_duplicate_slug_raises_integrity_error_no_partial_rows() -> None:
+    create_organization_with_admin(
+        email="a@x.be",
+        password="hunter22",
+        org_name="X1",
+        org_slug="x",
+        vat_number="BE0417710407",
+        billing_email="b@x.be",
+    )
+    org_count = Organization.objects.count()
+    user_count = User.objects.count()
+    mem_count = OrganizationMembership.objects.count()
+    with pytest.raises(IntegrityError):
+        create_organization_with_admin(
+            email="b@x.be",
+            password="hunter22",
+            org_name="X2",
+            org_slug="x",
+            vat_number="BE0417710407",
+            billing_email="b@x.be",
+        )
+    assert Organization.objects.count() == org_count
+    assert User.objects.count() == user_count
+    assert OrganizationMembership.objects.count() == mem_count
+
+
+@pytest.mark.django_db
+def test_duplicate_email_raises_integrity_error_no_partial_rows() -> None:
+    create_organization_with_admin(
+        email="a@x.be",
+        password="hunter22",
+        org_name="X1",
+        org_slug="x1",
+        vat_number="BE0417710407",
+        billing_email="b@x.be",
+    )
+    org_count = Organization.objects.count()
+    user_count = User.objects.count()
+    mem_count = OrganizationMembership.objects.count()
+    with pytest.raises(IntegrityError):
+        create_organization_with_admin(
+            email="A@X.BE",
+            password="hunter22",
+            org_name="X2",
+            org_slug="x2",
+            vat_number="BE0417710407",
+            billing_email="b@x.be",
+        )
+    assert Organization.objects.count() == org_count
+    assert User.objects.count() == user_count
+    assert OrganizationMembership.objects.count() == mem_count
+
+
+@pytest.mark.django_db
+def test_invalid_slug_raises_validation_error() -> None:
+    with pytest.raises(ValidationError):
+        create_organization_with_admin(
+            email="o@x.be",
+            password="hunter22",
+            org_name="X",
+            org_slug="NotASlug!",
+            vat_number="BE0417710407",
+            billing_email="b@x.be",
+        )
+
+
+@pytest.mark.django_db
+def test_vat_country_mismatch_raises_validation_error() -> None:
+    with pytest.raises(ValidationError):
+        create_organization_with_admin(
+            email="o@x.be",
+            password="hunter22",
+            org_name="X",
+            org_slug="x",
+            vat_number="FR12345678901",
+            billing_email="b@x.be",
+            country="BE",
+        )

--- a/whitepaper.md
+++ b/whitepaper.md
@@ -223,7 +223,7 @@ Same shape as invite, `salt="password-reset"`. Different salt prevents token reu
 - [x] `core.User` (custom, no `organization`, no `role`) and `Organization`. `AUTH_USER_MODEL = "core.User"` set in `config/settings/base.py`. *Organization in issue #3; `User` + `UserManager` (`create_user` / `create_superuser`) + `AUTH_USER_MODEL` in issue #4.*
 - [x] `makemigrations core`. *`0001_initial.py` covers `Organization` + `User` (with `Lower("email")` unique constraint, references `auth.0012` for `PermissionsMixin` M2Ms). `0002_organizationmembership.py` adds `OrganizationMembership` (issue #5). `0003_location_locationmembership.py` adds `Location` + `LocationMembership` (issues #6 / #7).*
 - [x] Add `Role` enum, `OrganizationMembership`, `Location`, `LocationMembership`. *`Role` + `OrganizationMembership` done in issue #5. `Location` + `LocationMembership` done in issues #6 / #7 (rename: was `Restaurant` / `RestaurantMembership`).*
-- [ ] `core/services/membership.py`: `deactivate_membership`, `change_role`, `deactivate_user` (each enforces the "last active ADMIN" invariant).
+- [x] `core/services/membership.py`: `deactivate_membership`, `change_role`, `deactivate_user` (each enforces the "last active ADMIN" invariant). *Issues #11/#12/#13. Also adds `core/services/signup.py:create_organization_with_admin` (issue #14) and `core/services/exceptions.py:LastActiveAdminError`.*
 - [ ] `core/managers.py`: `TenantOwnedManager` with `for_organization` and `for_request`.
 - [ ] Tenant middleware: resolves `request.organization` from `/o/<slug>/`, checks `OrganizationMembership` or `is_superuser`.
 - [x] `config/settings/base.py`: `LANGUAGES`, `LocaleMiddleware`, `locale/` folder, `USE_I18N=True`.


### PR DESCRIPTION
## Summary
- `LastActiveAdminError` and three membership service functions (`deactivate_membership`, `change_role`, `deactivate_user`) enforce the whitepaper §3 invariant - every active org keeps at least one qualifying ADMIN (`role==ADMIN AND is_active=True AND user.is_active=True`). Each runs under `transaction.atomic()` with org-row + membership/user `select_for_update` locks. `deactivate_user` aggregates all offending orgs into one error sorted by slug.
- `create_organization_with_admin` atomically creates `Organization` + `User` + ADMIN `OrganizationMembership`. Signature extended past issue #14 wording to include `vat_number`, `billing_email`, `country='BE'` because the model requires them; `full_clean(validate_unique=False)` runs slug regex + VAT/country validation while letting the DB enforce uniqueness (duplicates surface as `IntegrityError`).
- 29 new tests cover happy paths, idempotency, recovery scenarios (inactive user / inactive membership), and multi-org aggregation.

Closes #11, #12, #13, #14.

## Test plan
- [x] `uv run pytest` - 119/119 pass (90 prior + 29 new)
- [x] `uv run ruff check core/services tests/test_core_services_*` - clean
- [x] `uv run pyright core/` - 0 errors
- [x] Smoke in `manage.py shell`: `create_organization_with_admin(...)` returns `(org.is_active=False, user.is_active=False, role=ADMIN)`, password verifies via `check_password`

## Notes
- Locking uses `select_for_update` on the **org row** (per-org invariant pivot) plus the membership/user row. SQLite no-ops the lock; tests assert behavior, not SQL. Postgres deadlock is avoided by consistent ordering: org -> membership in single-membership ops, user -> orgs (sorted by pk) in `deactivate_user`.
- `core/services/__init__.py` is empty - explicit imports preferred (matches `core/utils/`).
- Whitepaper step 5 of "Implementation order" flipped to `[x]`. Lines 227-228 (`core/managers.py`, tenant middleware) are still `[ ]` despite PR #25/#26 landing them - left untouched as out-of-scope for this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)