### PR TITLE
feat(tests): factory-boy factories for foundation entities (#17)

### DIFF
--- a/tests/factories.py
+++ b/tests/factories.py
@@ -16,7 +16,13 @@ class UserFactory(DjangoModelFactory):
     class Meta:
         model = User
 
+    class Params:
+        staff = factory.Trait(is_staff=True)
+        superuser = factory.Trait(is_staff=True, is_superuser=True)
+
     email = factory.Sequence(lambda n: f"user{n}@example.be")
+    is_active = True
+    password = factory.PostGenerationMethodCall("set_password", "password")
 
 
 class OrganizationFactory(DjangoModelFactory):

--- a/tests/test_factories.py
+++ b/tests/test_factories.py
@@ -1,0 +1,51 @@
+import pytest
+
+from tests.factories import (
+    LocationFactory,
+    LocationMembershipFactory,
+    OrganizationFactory,
+    OrganizationMembershipFactory,
+    UserFactory,
+)
+
+
+@pytest.mark.django_db
+def test_each_factory_builds_valid_instance() -> None:
+    user = UserFactory()
+    assert user.pk is not None
+    assert user.is_active is True
+    assert user.check_password("password") is True
+
+    staff = UserFactory(staff=True)
+    assert staff.is_staff is True and staff.is_superuser is False
+
+    su = UserFactory(superuser=True)
+    assert su.is_staff is True and su.is_superuser is True
+
+    org = OrganizationFactory()
+    assert org.pk is not None
+
+    loc = LocationFactory()
+    assert loc.pk is not None and loc.organization_id is not None
+
+    om = OrganizationMembershipFactory()
+    assert om.pk is not None and om.user_id and om.organization_id
+
+    lm = LocationMembershipFactory()
+    assert lm.pk is not None and lm.user_id and lm.location_id
+
+
+def test_factories_have_no_collisions_over_100_builds() -> None:
+    emails = {UserFactory.build().email for _ in range(100)}
+    assert len(emails) == 100
+
+    org_slugs = {OrganizationFactory.build().slug for _ in range(100)}
+    assert len(org_slugs) == 100
+
+    billing_emails = {
+        OrganizationFactory.build().billing_email for _ in range(100)
+    }
+    assert len(billing_emails) == 100
+
+    loc_slugs = {LocationFactory.build().slug for _ in range(100)}
+    assert len(loc_slugs) == 100


### PR DESCRIPTION
## Summary
- Adds explicit `is_active=True`, a usable default password (`"password"`), and `staff` / `superuser` traits to `UserFactory`.
- New `tests/test_factories.py` smoke test: builds each of the 5 factories and asserts no collisions across 100 sequential builds.

Closes #17.

## Test plan
- [x] `pytest tests/test_factories.py -v` -> 2 passed
- [x] `pytest` -> 152 passed (no regressions in the 7 existing files using these factories)