### PR TITLE
feat(2a): {% field %} tag + form partials (#36)

### DIFF
--- a/core/templatetags/forms.py
+++ b/core/templatetags/forms.py
@@ -1,0 +1,58 @@
+from django import template
+from django.forms import BoundField
+from django.template.loader import render_to_string
+from django.utils.safestring import SafeString
+
+register = template.Library()
+
+
+@register.simple_tag
+def field(bound_field: BoundField, hint: str = "") -> SafeString:
+    has_error = bool(bound_field.errors)
+    is_bound = bound_field.form.is_bound
+
+    if has_error:
+        helper_text = " ".join(str(e) for e in bound_field.errors)
+    elif hint:
+        helper_text = hint
+    else:
+        helper_text = bound_field.help_text or ""
+
+    helper_id = f"{bound_field.auto_id}_helptext" if helper_text else ""
+
+    attrs: dict[str, str] = {}
+    if has_error:
+        attrs["aria-invalid"] = "true"
+    elif is_bound:
+        attrs["aria-invalid"] = "false"
+    if helper_id:
+        attrs["aria-describedby"] = helper_id
+
+    control = bound_field.as_widget(attrs=attrs)  # type: ignore[arg-type]
+
+    return render_to_string(
+        "forms/_field.html",
+        {
+            "field": bound_field,
+            "control": control,
+            "helper_text": helper_text,
+            "helper_id": helper_id,
+            "has_error": has_error,
+        },
+    )
+
+
+@register.simple_tag
+def submit(
+    primary_label: str,
+    secondary_label: str = "",
+    secondary_url: str = "",
+) -> SafeString:
+    return render_to_string(
+        "forms/_submit.html",
+        {
+            "primary_label": primary_label,
+            "secondary_label": secondary_label,
+            "secondary_url": secondary_url,
+        },
+    )

--- a/templates/forms/_errors.html
+++ b/templates/forms/_errors.html
@@ -1,0 +1,3 @@
+{% if form.non_field_errors %}<div role="alert" class="form-errors">
+<ul>{% for error in form.non_field_errors %}<li>{{ error }}</li>{% endfor %}</ul>
+</div>{% endif %}

--- a/templates/forms/_field.html
+++ b/templates/forms/_field.html
@@ -1,0 +1,3 @@
+<label for="{{ field.id_for_label }}">{{ field.label }}</label>
+{{ control }}
+{% if helper_text %}<small id="{{ helper_id }}"{% if has_error %} class="error"{% endif %}>{{ helper_text }}</small>{% endif %}

--- a/templates/forms/_submit.html
+++ b/templates/forms/_submit.html
@@ -1,0 +1,2 @@
+<button type="submit">{{ primary_label }}</button>
+{% if secondary_label %}<a href="{{ secondary_url }}" class="secondary" role="button">{{ secondary_label }}</a>{% endif %}

--- a/tests/test_forms_templatetags.py
+++ b/tests/test_forms_templatetags.py
@@ -1,0 +1,97 @@
+from django import forms
+from django.template import Context, Template
+
+
+class SampleForm(forms.Form):
+    email = forms.EmailField(help_text="We never share this.")
+    note = forms.CharField(disabled=True, required=False, initial="locked")
+
+
+def render(tpl: str, **ctx: object) -> str:
+    return Template("{% load forms %}" + tpl).render(Context(ctx))
+
+
+def test_field_valid_bound_renders_label_hint_and_aria() -> None:
+    form = SampleForm({"email": "ok@example.com"})
+    assert form.is_valid()
+    out = render("{% field form.email %}", form=form)
+
+    assert '<label for="id_email">' in out
+    assert 'aria-invalid="false"' in out
+    assert 'aria-describedby="id_email_helptext"' in out
+    assert '<small id="id_email_helptext"' in out
+    assert "We never share this." in out
+
+
+def test_field_invalid_bound_renders_error_and_aria_invalid() -> None:
+    form = SampleForm({"email": "nope"})
+    assert not form.is_valid()
+    out = render("{% field form.email %}", form=form)
+
+    assert 'aria-invalid="true"' in out
+    assert 'aria-describedby="id_email_helptext"' in out
+    assert 'class="error"' in out
+    assert "valid email" in out.lower()
+
+
+def test_field_unbound_has_no_aria_invalid() -> None:
+    form = SampleForm()
+    out = render("{% field form.email %}", form=form)
+
+    assert "aria-invalid" not in out
+    assert "We never share this." in out
+
+
+def test_field_explicit_hint_overrides_help_text() -> None:
+    form = SampleForm()
+    out = render('{% field form.email hint="Custom hint." %}', form=form)
+
+    assert "Custom hint." in out
+    assert "We never share this." not in out
+
+
+def test_field_disabled_attribute_preserved() -> None:
+    form = SampleForm()
+    out = render("{% field form.note %}", form=form)
+
+    assert "disabled" in out
+
+
+def test_submit_primary_only() -> None:
+    out = render('{% submit "Save" %}')
+
+    assert '<button type="submit">Save</button>' in out
+    assert "<a " not in out
+
+
+def test_submit_with_secondary() -> None:
+    out = render(
+        '{% submit "Save" secondary_label="Cancel" secondary_url="/back/" %}'
+    )
+
+    assert '<button type="submit">Save</button>' in out
+    assert 'href="/back/"' in out
+    assert ">Cancel<" in out
+    assert 'class="secondary"' in out
+
+
+def test_errors_partial_renders_non_field_errors() -> None:
+    form = SampleForm({"email": "ok@example.com"})
+    form.add_error(None, "Top-level boom.")
+    form.is_valid()
+    out = Template('{% include "forms/_errors.html" %}').render(
+        Context({"form": form})
+    )
+
+    assert 'role="alert"' in out
+    assert "Top-level boom." in out
+
+
+def test_errors_partial_silent_when_clean() -> None:
+    form = SampleForm({"email": "ok@example.com"})
+    assert form.is_valid()
+    out = Template('{% include "forms/_errors.html" %}').render(
+        Context({"form": form})
+    )
+
+    assert out.strip() == ""


### PR DESCRIPTION
Closes #36.

## Summary
- `core/templatetags/forms.py`: `{% field form.x [hint] %}` renders semantic `<label for>` + control + `<small>` helper text, with Pico's `aria-invalid` and `aria-describedby` wiring. `{% submit "label" [secondary_label=, secondary_url=] %}` renders the primary button plus optional secondary link.
- `templates/forms/_field.html`, `_errors.html`, `_submit.html`: small partials backing the tags. `_errors.html` is `{% include %}`-only (non-field errors block).
- `tests/test_forms_templatetags.py`: 9 tests covering valid bound, invalid bound, unbound, disabled, hint-override, both `{% submit %}` shapes, and `_errors.html` rendering.

### Decisions
- `aria-invalid="true"` on errors, `aria-invalid="false"` on valid bound fields (Pico convention, green-check styling). Omitted entirely on unbound forms.
- Checkbox / radio rendering deferred — Pico needs label-after-control wrapping; will land when 2b/2c need it.
- Helper text id is `{auto_id}_helptext`; `aria-describedby` is set whenever hint or error text is rendered.

## Test plan
- [x] `uv run pytest tests/test_forms_templatetags.py -v` (9 passed)
- [x] `uv run pytest` (165 passed)
- [x] `uv run ruff check core/templatetags/forms.py templates tests/test_forms_templatetags.py`
- [x] `uv run pyright core/templatetags/forms.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)