### PR TITLE
feat(2a): nav_top, user_menu, lang_switcher, flash, modal partials

### DIFF
--- a/config/urls.py
+++ b/config/urls.py
@@ -4,6 +4,7 @@ from django.urls import include, path
 
 urlpatterns = [
     path("admin/", admin.site.urls),
+    path("i18n/", include("django.conf.urls.i18n")),
     path("", include("core.urls")),
 ]
 

--- a/templates/_base.html
+++ b/templates/_base.html
@@ -10,6 +10,11 @@
   </head>
   <body class="{% block body_class %}{% endblock %}">
     {% block content %}{% endblock %}
+    {% include "_partials/modal.html" %}
+    <script>
+      document.body.addEventListener('modal:open', () => document.getElementById('modal')?.showModal());
+      document.body.addEventListener('modal:close', () => document.getElementById('modal')?.close());
+    </script>
     <script src="{% static 'js/htmx.min.js' %}" defer></script>
   </body>
 </html>

--- a/templates/_base.html
+++ b/templates/_base.html
@@ -12,8 +12,14 @@
     {% block content %}{% endblock %}
     {% include "_partials/modal.html" %}
     <script>
-      document.body.addEventListener('modal:open', () => document.getElementById('modal')?.showModal());
-      document.body.addEventListener('modal:close', () => document.getElementById('modal')?.close());
+      document.body.addEventListener('modal:open', () => {
+        const m = document.getElementById('modal');
+        if (m && !m.open) m.showModal();
+      });
+      document.body.addEventListener('modal:close', () => {
+        const m = document.getElementById('modal');
+        if (m && m.open) m.close();
+      });
     </script>
     <script src="{% static 'js/htmx.min.js' %}" defer></script>
   </body>

--- a/templates/_partials/flash.html
+++ b/templates/_partials/flash.html
@@ -1,0 +1,1 @@
+{% load i18n %}<div id="flash">{% if messages %}{% for message in messages %}<article class="message{% if message.tags %} message-{{ message.tags }}{% endif %}" role="{% if message.level >= 30 %}alert{% else %}status{% endif %}">{{ message }}</article>{% endfor %}{% endif %}</div>

--- a/templates/_partials/lang_switcher.html
+++ b/templates/_partials/lang_switcher.html
@@ -1,0 +1,4 @@
+{% load i18n %}{% if request.user.is_anonymous or not request.user.preferred_language %}{% get_available_languages as LANGUAGES %}{% get_current_language as CURRENT_LANG %}<form action="{% url 'set_language' %}" method="post" class="lang-switcher">{% csrf_token %}<input type="hidden" name="next" value="{{ request.path }}">
+<select name="language" aria-label="{% trans 'Change language' %}">{% for code, name in LANGUAGES %}<option value="{{ code }}"{% if code == CURRENT_LANG %} selected{% endif %}>{{ name }}</option>{% endfor %}</select>
+<button type="submit" class="secondary">{% trans "Change language" %}</button>
+</form>{% endif %}

--- a/templates/_partials/lang_switcher.html
+++ b/templates/_partials/lang_switcher.html
@@ -1,4 +1,4 @@
-{% load i18n %}{% if request.user.is_anonymous or not request.user.preferred_language %}{% get_available_languages as LANGUAGES %}{% get_current_language as CURRENT_LANG %}<form action="{% url 'set_language' %}" method="post" class="lang-switcher">{% csrf_token %}<input type="hidden" name="next" value="{{ request.path }}">
+{% load i18n %}{% if request.user.is_anonymous or not request.user.preferred_language %}{% get_available_languages as LANGUAGES %}{% get_current_language as CURRENT_LANG %}<form action="{% url 'set_language' %}" method="post" class="lang-switcher">{% csrf_token %}<input type="hidden" name="next" value="{{ request.get_full_path }}">
 <select name="language" aria-label="{% trans 'Change language' %}">{% for code, name in LANGUAGES %}<option value="{{ code }}"{% if code == CURRENT_LANG %} selected{% endif %}>{{ name }}</option>{% endfor %}</select>
 <button type="submit" class="secondary">{% trans "Change language" %}</button>
 </form>{% endif %}

--- a/templates/_partials/modal.html
+++ b/templates/_partials/modal.html
@@ -1,0 +1,1 @@
+<dialog id="modal"><article>{% block modal_body %}{% endblock %}</article></dialog>

--- a/templates/_partials/nav_top.html
+++ b/templates/_partials/nav_top.html
@@ -1,0 +1,12 @@
+{% load i18n %}<header class="nav-top container-fluid">
+<nav>
+<ul>
+<li><strong><a href="/" class="contrast">rapido</a></strong></li>
+{% if request.organization %}<li>{{ request.organization.name }}</li>{% endif %}
+</ul>
+<ul>
+<li>{% include "_partials/lang_switcher.html" %}</li>
+<li>{% include "_partials/user_menu.html" %}</li>
+</ul>
+</nav>
+</header>

--- a/templates/_partials/user_menu.html
+++ b/templates/_partials/user_menu.html
@@ -1,0 +1,4 @@
+{% load i18n %}{% if request.user.is_authenticated %}<details class="dropdown user-menu">
+<summary>{% if request.user.first_name or request.user.last_name %}{{ request.user.first_name }} {{ request.user.last_name }}{% else %}{{ request.user.email }}{% endif %}</summary>
+<ul>{% url 'profile' as profile_url %}{% if profile_url %}<li><a href="{{ profile_url }}">{% trans "Profile" %}</a></li>{% endif %}{% url 'logout' as logout_url %}{% if logout_url %}<li><form method="post" action="{{ logout_url }}">{% csrf_token %}<button type="submit" class="secondary">{% trans "Sign out" %}</button></form></li>{% endif %}</ul>
+</details>{% endif %}

--- a/templates/base_org.html
+++ b/templates/base_org.html
@@ -5,10 +5,11 @@
 
 {% block content %}
   <a class="skip-link" href="#main">{% trans "Skip to content" %}</a>
-  {% block topbar %}{% endblock %}
+  {% block topbar %}{% include "_partials/nav_top.html" %}{% endblock %}
   <div class="org-layout container">
     <aside class="rail">{% block rail %}{% endblock %}</aside>
     <main id="main">
+      {% include "_partials/flash.html" %}
       {% block main %}{% endblock %}
     </main>
   </div>

--- a/templates/base_picker.html
+++ b/templates/base_picker.html
@@ -5,8 +5,9 @@
 
 {% block content %}
   <a class="skip-link" href="#main">{% trans "Skip to content" %}</a>
-  {% block topbar %}{% endblock %}
+  {% block topbar %}{% include "_partials/nav_top.html" %}{% endblock %}
   <main id="main" class="container">
+    {% include "_partials/flash.html" %}
     {% block main %}{% endblock %}
   </main>
 {% endblock %}

--- a/templates/base_public.html
+++ b/templates/base_public.html
@@ -6,6 +6,7 @@
 {% block content %}
   <a class="skip-link" href="#main">{% trans "Skip to content" %}</a>
   <main id="main" class="container">
+    {% include "_partials/flash.html" %}
     {% block main %}{% endblock %}
   </main>
 {% endblock %}

--- a/tests/test_design_partials.py
+++ b/tests/test_design_partials.py
@@ -1,0 +1,265 @@
+import pytest
+from django.conf import settings
+from django.contrib.auth.models import AbstractBaseUser, AnonymousUser
+from django.contrib.messages import constants as message_levels
+from django.contrib.messages.storage.base import Message
+from django.http import HttpRequest, HttpResponse
+from django.template import Context, RequestContext, Template
+from django.test import RequestFactory, override_settings
+from django.urls import include, path
+
+from core.models import Organization
+from tests.factories import OrganizationFactory, UserFactory
+
+
+def _stub(request: HttpRequest) -> HttpResponse:
+    del request
+    return HttpResponse()
+
+
+urlpatterns = [
+    path("logout/", _stub, name="logout"),
+    path("profile/", _stub, name="profile"),
+    path("i18n/", include("django.conf.urls.i18n")),
+]
+
+
+def _request(
+    path: str = "/",
+    user: AbstractBaseUser | AnonymousUser | None = None,
+    organization: Organization | None = None,
+) -> HttpRequest:
+    rf = RequestFactory()
+    req = rf.get(path)
+    req.user = user if user is not None else AnonymousUser()  # type: ignore[assignment]
+    req.organization = organization  # type: ignore[attr-defined]
+    return req
+
+
+def _render_include(
+    template_path: str,
+    request: HttpRequest | None = None,
+    **ctx: object,
+) -> str:
+    tpl = Template('{% include "' + template_path + '" %}')
+    if request is not None:
+        return tpl.render(RequestContext(request, ctx))
+    return tpl.render(Context(ctx))
+
+
+# ---------- nav_top ----------
+
+
+def test_nav_top_anonymous_renders_brand_and_lang_switcher() -> None:
+    out = _render_include("_partials/nav_top.html", request=_request())
+    assert ">rapido<" in out
+    assert "/i18n/setlang/" in out
+
+
+@pytest.mark.django_db
+def test_nav_top_shows_org_name_when_org_in_context() -> None:
+    org = OrganizationFactory(name="Frituur Centrale")
+    user = UserFactory()
+    out = _render_include(
+        "_partials/nav_top.html",
+        request=_request(user=user, organization=org),
+    )
+    assert "Frituur Centrale" in out
+
+
+@pytest.mark.django_db
+def test_nav_top_omits_org_name_without_org_context() -> None:
+    user = UserFactory()
+    out = _render_include("_partials/nav_top.html", request=_request(user=user))
+    assert "<li>" in out
+    assert "Frituur" not in out
+
+
+# ---------- user_menu ----------
+
+
+def test_user_menu_silent_for_anonymous() -> None:
+    out = _render_include(
+        "_partials/user_menu.html", request=_request(user=AnonymousUser())
+    )
+    assert "<details" not in out
+    assert "Profile" not in out
+    assert "Sign out" not in out
+
+
+@pytest.mark.django_db
+def test_user_menu_shows_full_name_when_set() -> None:
+    user = UserFactory(first_name="Alice", last_name="Brown")
+    out = _render_include(
+        "_partials/user_menu.html", request=_request(user=user)
+    )
+    assert "Alice Brown" in out
+
+
+@pytest.mark.django_db
+def test_user_menu_falls_back_to_email_when_name_blank() -> None:
+    user = UserFactory(first_name="", last_name="", email="alice@example.be")
+    out = _render_include(
+        "_partials/user_menu.html", request=_request(user=user)
+    )
+    assert "alice@example.be" in out
+
+
+@pytest.mark.django_db
+def test_user_menu_omits_profile_and_logout_when_urls_undefined() -> None:
+    user = UserFactory()
+    out = _render_include(
+        "_partials/user_menu.html", request=_request(user=user)
+    )
+    assert "Profile" not in out
+    assert "Sign out" not in out
+
+
+@pytest.mark.django_db
+@override_settings(ROOT_URLCONF=__name__)
+def test_user_menu_renders_profile_and_logout_when_urls_defined() -> None:
+    user = UserFactory()
+    out = _render_include(
+        "_partials/user_menu.html", request=_request(user=user)
+    )
+    assert 'href="/profile/"' in out
+    assert "Profile" in out
+    assert 'action="/logout/"' in out
+    assert 'method="post"' in out
+    assert "Sign out" in out
+    assert "csrfmiddlewaretoken" in out
+
+
+# ---------- lang_switcher ----------
+
+
+def test_lang_switcher_visible_for_anonymous() -> None:
+    out = _render_include(
+        "_partials/lang_switcher.html",
+        request=_request(user=AnonymousUser()),
+    )
+    assert "<form" in out
+    assert 'action="/i18n/setlang/"' in out
+
+
+@pytest.mark.django_db
+def test_lang_switcher_hidden_for_user_with_preferred_language() -> None:
+    user = UserFactory(preferred_language="nl-BE")
+    out = _render_include(
+        "_partials/lang_switcher.html", request=_request(user=user)
+    )
+    assert out.strip() == ""
+
+
+@pytest.mark.django_db
+def test_lang_switcher_visible_for_user_with_empty_preferred_language() -> None:
+    user = UserFactory(preferred_language="")
+    out = _render_include(
+        "_partials/lang_switcher.html", request=_request(user=user)
+    )
+    assert "<form" in out
+
+
+def test_lang_switcher_next_field_equals_request_path() -> None:
+    out = _render_include(
+        "_partials/lang_switcher.html",
+        request=_request(path="/o/acme/dashboard/", user=AnonymousUser()),
+    )
+    assert 'name="next"' in out
+    assert 'value="/o/acme/dashboard/"' in out
+
+
+def test_lang_switcher_lists_all_supported_languages() -> None:
+    out = _render_include(
+        "_partials/lang_switcher.html",
+        request=_request(user=AnonymousUser()),
+    )
+    for code, _ in settings.LANGUAGES:
+        assert f'value="{code}"' in out
+
+
+def test_lang_switcher_includes_csrf_token() -> None:
+    out = _render_include(
+        "_partials/lang_switcher.html",
+        request=_request(user=AnonymousUser()),
+    )
+    assert "csrfmiddlewaretoken" in out
+
+
+# ---------- flash ----------
+
+
+def _msg(level: int, content: str, extra_tags: str = "") -> Message:
+    return Message(level=level, message=content, extra_tags=extra_tags)
+
+
+def test_flash_wrapper_id_present_when_no_messages() -> None:
+    out = _render_include("_partials/flash.html")
+    assert 'id="flash"' in out
+    assert "<article" not in out
+
+
+def test_flash_renders_one_article_per_message() -> None:
+    msgs = [
+        _msg(message_levels.INFO, "Hi"),
+        _msg(message_levels.SUCCESS, "OK"),
+    ]
+    out = _render_include("_partials/flash.html", messages=msgs)
+    assert out.count("<article") == 2
+    assert "Hi" in out
+    assert "OK" in out
+
+
+def test_flash_uses_alert_role_for_warning_and_error() -> None:
+    msgs = [
+        _msg(message_levels.WARNING, "warn"),
+        _msg(message_levels.ERROR, "err"),
+    ]
+    out = _render_include("_partials/flash.html", messages=msgs)
+    assert out.count('role="alert"') == 2
+
+
+def test_flash_uses_status_role_for_info_and_success() -> None:
+    msgs = [
+        _msg(message_levels.INFO, "i"),
+        _msg(message_levels.SUCCESS, "s"),
+    ]
+    out = _render_include("_partials/flash.html", messages=msgs)
+    assert out.count('role="status"') == 2
+
+
+def test_flash_includes_message_tag_class() -> None:
+    msgs = [_msg(message_levels.SUCCESS, "ok")]
+    out = _render_include("_partials/flash.html", messages=msgs)
+    assert "message-success" in out
+
+
+# ---------- modal ----------
+
+
+def test_modal_uses_native_dialog() -> None:
+    out = _render_include("_partials/modal.html")
+    assert "<dialog" in out
+    assert 'id="modal"' in out
+    assert "</dialog>" in out
+
+
+def test_modal_body_block_is_overridable() -> None:
+    tpl = Template(
+        '{% extends "_partials/modal.html" %}'
+        "{% block modal_body %}<p>hello inside.</p>{% endblock %}"
+    )
+    out = tpl.render(Context({}))
+    assert "<p>hello inside.</p>" in out
+
+
+# ---------- _base.html modal listeners ----------
+
+
+def test_base_html_includes_modal_open_and_close_listeners() -> None:
+    out = Template('{% extends "base_public.html" %}').render(
+        RequestContext(_request())
+    )
+    assert "modal:open" in out
+    assert "modal:close" in out
+    assert "showModal()" in out

--- a/tests/test_design_partials.py
+++ b/tests/test_design_partials.py
@@ -169,6 +169,17 @@ def test_lang_switcher_next_field_equals_request_path() -> None:
     assert 'value="/o/acme/dashboard/"' in out
 
 
+def test_lang_switcher_next_field_preserves_query_string() -> None:
+    out = _render_include(
+        "_partials/lang_switcher.html",
+        request=_request(
+            path="/o/acme/orders/?status=paid&page=2",
+            user=AnonymousUser(),
+        ),
+    )
+    assert 'value="/o/acme/orders/?status=paid&amp;page=2"' in out
+
+
 def test_lang_switcher_lists_all_supported_languages() -> None:
     out = _render_include(
         "_partials/lang_switcher.html",


### PR DESCRIPTION
## Summary
- Adds the five shared partials called out in epic 2a (`nav_top`, `user_menu`, `lang_switcher`, `flash`, `modal`) and mounts them into `_base.html` + the three layout shells so 2b/2c can consume them as-is.
- Wires `path("i18n/", include("django.conf.urls.i18n"))` so the language form has a real endpoint.
- Uses defensive `{% url 'name' as var %}` for `logout` / `profile` so the user_menu renders cleanly today and lights up automatically when 2b adds those routes.
- 22 structural tests in `tests/test_design_partials.py`; full suite is 187 passing.

Closes #38.

## Notes
- `lang_switcher` is suppressed for signed-in users with a stored `preferred_language`, visible for anonymous users and users without a preference.
- Modal opens via `HX-Trigger: modal:open` (close via `modal:close` or native Esc); listener is 4 lines in `_base.html`.
- No CSS authored in this PR - Pico styles `<details class="dropdown">`, `<dialog>`, and the flash `<article>`s. Brand polish is a follow-up if needed.
- Org switcher is intentionally out of scope; it lives more naturally with multi-org UX in 2b/2c.

## Test plan
- [x] `uv run pytest tests/test_design_partials.py` - 22 pass
- [x] `uv run pytest` - full suite green (187 pass)
- [x] `uv run ruff check . && uv run ruff format --check .` - clean
- [x] `uv run python manage.py check` - 0 issues
- [x] Smoke: render `base_picker.html` for an anonymous request - header, brand, flash, dialog, and modal listeners all present
- [ ] Manual browser sanity (reviewer): runserver, hit a stub view per shell, confirm topbar + lang form + flash + modal trigger via `htmx.trigger(document.body, 'modal:open')`

🤖 Generated with [Claude Code](https://claude.com/claude-code)