### PR TITLE
feat(2b): signed-token helpers (#49)

### DIFF
--- a/core/services/tokens.py
+++ b/core/services/tokens.py
@@ -1,0 +1,20 @@
+from typing import Any
+
+from django.core import signing
+
+from core.models import User
+
+VERIFY_SALT = "verify-email"
+RESET_SALT = "password-reset"
+INVITE_SALT = "invite"
+
+VERIFY_MAX_AGE = 7 * 24 * 3600
+RESET_MAX_AGE = 3600
+
+
+def make_token(user: User, *, salt: str) -> str:
+    return signing.dumps({"user_id": user.pk}, salt=salt)
+
+
+def verify_token(token: str, *, salt: str, max_age: int) -> dict[str, Any]:
+    return signing.loads(token, salt=salt, max_age=max_age)

--- a/tests/test_core_services_tokens.py
+++ b/tests/test_core_services_tokens.py
@@ -1,0 +1,52 @@
+import pytest
+from django.core.signing import BadSignature, SignatureExpired
+
+from core.services.tokens import (
+    INVITE_SALT,
+    RESET_MAX_AGE,
+    RESET_SALT,
+    VERIFY_MAX_AGE,
+    VERIFY_SALT,
+    make_token,
+    verify_token,
+)
+from tests.factories import UserFactory
+
+
+@pytest.mark.django_db
+def test_round_trip_returns_user_id() -> None:
+    user = UserFactory()
+    token = make_token(user, salt=VERIFY_SALT)
+    payload = verify_token(token, salt=VERIFY_SALT, max_age=VERIFY_MAX_AGE)
+    assert payload == {"user_id": user.pk}
+
+
+@pytest.mark.django_db
+def test_tampered_token_raises_bad_signature() -> None:
+    user = UserFactory()
+    token = make_token(user, salt=VERIFY_SALT)
+    tampered = token[:-1] + ("A" if token[-1] != "A" else "B")
+    with pytest.raises(BadSignature):
+        verify_token(tampered, salt=VERIFY_SALT, max_age=VERIFY_MAX_AGE)
+
+
+@pytest.mark.django_db
+def test_expired_token_raises_signature_expired() -> None:
+    user = UserFactory()
+    token = make_token(user, salt=RESET_SALT)
+    with pytest.raises(SignatureExpired):
+        verify_token(token, salt=RESET_SALT, max_age=-1)
+
+
+@pytest.mark.django_db
+def test_cross_salt_reuse_rejected() -> None:
+    user = UserFactory()
+    token = make_token(user, salt=VERIFY_SALT)
+    with pytest.raises(BadSignature):
+        verify_token(token, salt=RESET_SALT, max_age=RESET_MAX_AGE)
+
+
+def test_salt_constants_are_locked() -> None:
+    assert VERIFY_SALT == "verify-email"
+    assert RESET_SALT == "password-reset"
+    assert INVITE_SALT == "invite"


### PR DESCRIPTION
## Summary
- Add `core/services/tokens.py` with `VERIFY_SALT` / `RESET_SALT` / `INVITE_SALT`, `VERIFY_MAX_AGE` / `RESET_MAX_AGE`, and thin `make_token` / `verify_token` wrappers around `django.core.signing`.
- Payload is `{"user_id": user.pk}`; `BadSignature` / `SignatureExpired` propagate to callers.
- `INVITE_SALT` constant only - max_age owned by epic 2c.

Closes #49. Implements step 3 of the epic 2b implementation order.

## Test plan
- [x] Round-trip: `verify_token(make_token(...))` returns `{"user_id": pk}`
- [x] Tampered token raises `BadSignature`
- [x] Expired token (max_age=-1) raises `SignatureExpired`
- [x] Cross-salt reuse (sign with verify, load with reset) raises `BadSignature`
- [x] Salt constants locked to documented strings

\`uv run pytest tests/test_core_services_tokens.py\` -> 5 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)