### PR TITLE
feat(2b): signup default_language + on_commit verify email + activate_from_token

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -147,6 +147,8 @@ DEFAULT_FROM_EMAIL = env(
     default="noreply@localhost",  # type: ignore[arg-type]
 )
 SITE_BRAND = env("SITE_BRAND", default="Rapido")  # type: ignore[arg-type]
+# Absolute base for transactional email links (no trailing slash).
+SITE_URL = env("SITE_URL", default="http://localhost:8000")  # type: ignore[arg-type]
 
 LOGIN_URL = "/login/"
 LOGIN_REDIRECT_URL = "/orgs/"

--- a/core/services/activation.py
+++ b/core/services/activation.py
@@ -1,0 +1,32 @@
+from django.db import transaction
+
+from core.models import OrganizationMembership, Role, User
+from core.services.exceptions import (
+    AlreadyActiveError,
+    NoAdminMembershipError,
+)
+from core.services.tokens import VERIFY_MAX_AGE, VERIFY_SALT, verify_token
+
+
+def activate_from_token(token: str) -> User:
+    payload = verify_token(token, salt=VERIFY_SALT, max_age=VERIFY_MAX_AGE)
+    user_id = payload["user_id"]
+    with transaction.atomic():
+        user = User.objects.select_for_update().get(pk=user_id)
+        if user.is_active:
+            raise AlreadyActiveError
+        mem = (
+            OrganizationMembership.objects.select_for_update()
+            .select_related("organization")
+            .filter(user=user, role=Role.ADMIN, is_active=True)
+            .order_by("created_at")
+            .first()
+        )
+        if mem is None:
+            raise NoAdminMembershipError
+        user.is_active = True
+        user.save()
+        org = mem.organization
+        org.is_active = True
+        org.save()
+        return user

--- a/core/services/exceptions.py
+++ b/core/services/exceptions.py
@@ -13,3 +13,11 @@ class LastActiveAdminError(Exception):
             f"Operation would leave organization(s) without an active "
             f"ADMIN: {slugs}"
         )
+
+
+class AlreadyActiveError(Exception):
+    """User is already active; verify token reuse is a no-op at the page."""
+
+
+class NoAdminMembershipError(Exception):
+    """User has no active ADMIN membership to anchor org activation."""

--- a/core/services/signup.py
+++ b/core/services/signup.py
@@ -1,6 +1,10 @@
+from django.conf import settings
 from django.db import transaction
+from django.urls import reverse
 
 from core.models import Organization, OrganizationMembership, Role, User
+from core.services.mail import send_templated
+from core.services.tokens import VERIFY_SALT, make_token
 
 
 def create_organization_with_admin(
@@ -11,6 +15,7 @@ def create_organization_with_admin(
     org_slug: str,
     vat_number: str,
     billing_email: str,
+    default_language: str,
     country: str = "BE",
 ) -> tuple[Organization, User, OrganizationMembership]:
     with transaction.atomic():
@@ -20,6 +25,7 @@ def create_organization_with_admin(
             vat_number=vat_number,
             billing_email=billing_email,
             country=country,
+            default_language=default_language,
             is_active=False,
         )
         # Run slug regex + VAT/country invariant. Skip uniqueness so
@@ -27,7 +33,10 @@ def create_organization_with_admin(
         org.full_clean(validate_unique=False)
         org.save()
         user = User.objects.create_user(
-            email=email, password=password, is_active=False
+            email=email,
+            password=password,
+            is_active=False,
+            preferred_language=default_language,
         )
         membership = OrganizationMembership.objects.create(
             user=user,
@@ -35,5 +44,17 @@ def create_organization_with_admin(
             role=Role.ADMIN,
             is_active=True,
             created_by=None,
+        )
+        token = make_token(user, salt=VERIFY_SALT)
+        verify_url = (
+            f"{settings.SITE_URL}{reverse('core:verify', args=[token])}"
+        )
+        transaction.on_commit(
+            lambda: send_templated(
+                "email/verify",
+                to=user,
+                language=org.default_language,
+                context={"verify_url": verify_url, "org_name": org.name},
+            )
         )
         return org, user, membership

--- a/core/services/signup.py
+++ b/core/services/signup.py
@@ -1,3 +1,5 @@
+import logging
+
 from django.conf import settings
 from django.db import transaction
 from django.urls import reverse
@@ -5,6 +7,25 @@ from django.urls import reverse
 from core.models import Organization, OrganizationMembership, Role, User
 from core.services.mail import send_templated
 from core.services.tokens import VERIFY_SALT, make_token
+
+logger = logging.getLogger(__name__)
+
+
+def _send_verify_email(
+    *, user: User, language: str, verify_url: str, org_name: str
+) -> None:
+    # Best-effort: signup has already committed. Log and swallow so SMTP
+    # or template errors don't masquerade as a failed signup. The resend-
+    # verify flow (epic 2b §3) is idempotent and recovers stuck users.
+    try:
+        send_templated(
+            "email/verify",
+            to=user,
+            language=language,
+            context={"verify_url": verify_url, "org_name": org_name},
+        )
+    except Exception:
+        logger.exception("verify email send failed for user_id=%s", user.pk)
 
 
 def create_organization_with_admin(
@@ -50,11 +71,11 @@ def create_organization_with_admin(
             f"{settings.SITE_URL}{reverse('core:verify', args=[token])}"
         )
         transaction.on_commit(
-            lambda: send_templated(
-                "email/verify",
-                to=user,
+            lambda: _send_verify_email(
+                user=user,
                 language=org.default_language,
-                context={"verify_url": verify_url, "org_name": org.name},
+                verify_url=verify_url,
+                org_name=org.name,
             )
         )
         return org, user, membership

--- a/core/urls.py
+++ b/core/urls.py
@@ -3,12 +3,14 @@ from django.urls import path
 from django.urls.resolvers import URLPattern
 
 from .views import home
+from .views.auth import verify_placeholder
 from .views.design import design_kitchen_sink
 
 app_name = "core"
 
 urlpatterns: list[URLPattern] = [
     path(route="", view=home, name="home"),
+    path(route="verify/<str:token>/", view=verify_placeholder, name="verify"),
 ]
 
 if settings.DEBUG:

--- a/core/views/auth.py
+++ b/core/views/auth.py
@@ -1,0 +1,6 @@
+from django.http import HttpRequest, HttpResponse
+
+
+def verify_placeholder(request: HttpRequest, token: str) -> HttpResponse:
+    del request, token
+    return HttpResponse(status=501)

--- a/tests/test_core_services_activation.py
+++ b/tests/test_core_services_activation.py
@@ -1,0 +1,98 @@
+from unittest.mock import patch
+
+import pytest
+from django.core import signing
+from django.db import connection
+from django.test.utils import CaptureQueriesContext
+
+from core.models import Role
+from core.services.activation import activate_from_token
+from core.services.exceptions import (
+    AlreadyActiveError,
+    NoAdminMembershipError,
+)
+from core.services.tokens import VERIFY_SALT, make_token
+from tests.factories import (
+    OrganizationFactory,
+    OrganizationMembershipFactory,
+    UserFactory,
+)
+
+
+@pytest.mark.django_db
+def test_activate_flips_both_flags_and_returns_user() -> None:
+    user = UserFactory(is_active=False)
+    org = OrganizationFactory(is_active=False)
+    OrganizationMembershipFactory(user=user, organization=org, role=Role.ADMIN)
+    token = make_token(user, salt=VERIFY_SALT)
+
+    result = activate_from_token(token)
+
+    user.refresh_from_db()
+    org.refresh_from_db()
+    assert result == user
+    assert user.is_active is True
+    assert org.is_active is True
+
+
+@pytest.mark.django_db
+def test_already_active_user_raises() -> None:
+    user = UserFactory(is_active=False)
+    org = OrganizationFactory(is_active=False)
+    OrganizationMembershipFactory(user=user, organization=org, role=Role.ADMIN)
+    token = make_token(user, salt=VERIFY_SALT)
+
+    activate_from_token(token)
+    with pytest.raises(AlreadyActiveError):
+        activate_from_token(token)
+
+
+@pytest.mark.django_db
+def test_bad_signature_propagates() -> None:
+    with pytest.raises(signing.BadSignature):
+        activate_from_token("not-a-real-token")
+
+
+@pytest.mark.django_db
+def test_signature_expired_propagates() -> None:
+    user = UserFactory(is_active=False)
+    org = OrganizationFactory(is_active=False)
+    OrganizationMembershipFactory(user=user, organization=org, role=Role.ADMIN)
+    token = make_token(user, salt=VERIFY_SALT)
+    with (
+        patch(
+            "core.services.activation.verify_token",
+            side_effect=signing.SignatureExpired("expired"),
+        ),
+        pytest.raises(signing.SignatureExpired),
+    ):
+        activate_from_token(token)
+
+
+@pytest.mark.django_db
+def test_no_active_admin_membership_raises() -> None:
+    user = UserFactory(is_active=False)
+    org = OrganizationFactory(is_active=False)
+    OrganizationMembershipFactory(
+        user=user, organization=org, role=Role.OPERATOR
+    )
+    token = make_token(user, salt=VERIFY_SALT)
+    with pytest.raises(NoAdminMembershipError):
+        activate_from_token(token)
+
+
+@pytest.mark.django_db(transaction=True)
+def test_activation_uses_select_for_update() -> None:
+    if connection.vendor == "sqlite":
+        pytest.skip("SQLite ignores SELECT ... FOR UPDATE")
+    user = UserFactory(is_active=False)
+    org = OrganizationFactory(is_active=False)
+    OrganizationMembershipFactory(user=user, organization=org, role=Role.ADMIN)
+    token = make_token(user, salt=VERIFY_SALT)
+
+    with CaptureQueriesContext(connection) as ctx:
+        activate_from_token(token)
+
+    sqls = [q["sql"].upper() for q in ctx.captured_queries]
+    locked = [s for s in sqls if "FOR UPDATE" in s]
+    assert len(locked) >= 2

--- a/tests/test_core_services_signup.py
+++ b/tests/test_core_services_signup.py
@@ -1,9 +1,15 @@
+from typing import Any
+from unittest.mock import patch
+
 import pytest
+from django.conf import settings
 from django.core.exceptions import ValidationError
-from django.db import IntegrityError
+from django.db import IntegrityError, transaction
 
 from core.models import Organization, OrganizationMembership, Role, User
 from core.services.signup import create_organization_with_admin
+
+_Capture = Any
 
 
 @pytest.mark.django_db
@@ -15,6 +21,7 @@ def test_creates_all_three_rows() -> None:
         org_slug="x",
         vat_number="BE0417710407",
         billing_email="b@x.be",
+        default_language="en-US",
     )
     assert org.is_active is False
     assert user.is_active is False
@@ -33,6 +40,7 @@ def test_normalizes_email_to_lowercase() -> None:
         org_slug="x",
         vat_number="BE0417710407",
         billing_email="b@x.be",
+        default_language="en-US",
     )
     assert user.email == "foo@example.be"
 
@@ -46,6 +54,7 @@ def test_returns_three_tuple_of_correct_types() -> None:
         org_slug="x",
         vat_number="BE0417710407",
         billing_email="b@x.be",
+        default_language="en-US",
     )
     assert isinstance(result, tuple)
     assert len(result) == 3
@@ -63,6 +72,7 @@ def test_duplicate_slug_raises_integrity_error_no_partial_rows() -> None:
         org_slug="x",
         vat_number="BE0417710407",
         billing_email="b@x.be",
+        default_language="en-US",
     )
     org_count = Organization.objects.count()
     user_count = User.objects.count()
@@ -75,6 +85,7 @@ def test_duplicate_slug_raises_integrity_error_no_partial_rows() -> None:
             org_slug="x",
             vat_number="BE0417710407",
             billing_email="b@x.be",
+            default_language="en-US",
         )
     assert Organization.objects.count() == org_count
     assert User.objects.count() == user_count
@@ -90,6 +101,7 @@ def test_duplicate_email_raises_integrity_error_no_partial_rows() -> None:
         org_slug="x1",
         vat_number="BE0417710407",
         billing_email="b@x.be",
+        default_language="en-US",
     )
     org_count = Organization.objects.count()
     user_count = User.objects.count()
@@ -102,6 +114,7 @@ def test_duplicate_email_raises_integrity_error_no_partial_rows() -> None:
             org_slug="x2",
             vat_number="BE0417710407",
             billing_email="b@x.be",
+            default_language="en-US",
         )
     assert Organization.objects.count() == org_count
     assert User.objects.count() == user_count
@@ -118,6 +131,7 @@ def test_invalid_slug_raises_validation_error() -> None:
             org_slug="NotASlug!",
             vat_number="BE0417710407",
             billing_email="b@x.be",
+            default_language="en-US",
         )
 
 
@@ -132,4 +146,72 @@ def test_vat_country_mismatch_raises_validation_error() -> None:
             vat_number="FR12345678901",
             billing_email="b@x.be",
             country="BE",
+            default_language="en-US",
         )
+
+
+@pytest.mark.django_db
+def test_default_language_persisted_on_org_and_user() -> None:
+    org, user, _ = create_organization_with_admin(
+        email="o@x.be",
+        password="hunter22",
+        org_name="X",
+        org_slug="x",
+        vat_number="BE0417710407",
+        billing_email="b@x.be",
+        default_language="nl-BE",
+    )
+    org.refresh_from_db()
+    user.refresh_from_db()
+    assert org.default_language == "nl-BE"
+    assert user.preferred_language == "nl-BE"
+
+
+@pytest.mark.django_db
+def test_verify_email_enqueued_on_commit(
+    django_capture_on_commit_callbacks: _Capture,
+) -> None:
+    with patch("core.services.signup.send_templated") as send:
+        with django_capture_on_commit_callbacks(execute=True) as callbacks:
+            _, user, _ = create_organization_with_admin(
+                email="o@x.be",
+                password="hunter22",
+                org_name="X",
+                org_slug="x",
+                vat_number="BE0417710407",
+                billing_email="b@x.be",
+                default_language="nl-BE",
+            )
+        assert len(callbacks) == 1
+        send.assert_called_once()
+        args, kwargs = send.call_args
+        assert args == ("email/verify",)
+        assert kwargs["to"] == user
+        assert kwargs["language"] == "nl-BE"
+        assert kwargs["context"]["org_name"] == "X"
+        assert kwargs["context"]["verify_url"].startswith(
+            f"{settings.SITE_URL}/verify/"
+        )
+
+
+@pytest.mark.django_db
+def test_email_not_sent_if_transaction_rolls_back(
+    django_capture_on_commit_callbacks: _Capture,
+) -> None:
+    with (
+        patch("core.services.signup.send_templated") as send,
+        django_capture_on_commit_callbacks(execute=True),
+        pytest.raises(RuntimeError),
+        transaction.atomic(),
+    ):
+        create_organization_with_admin(
+            email="o@x.be",
+            password="hunter22",
+            org_name="X",
+            org_slug="x",
+            vat_number="BE0417710407",
+            billing_email="b@x.be",
+            default_language="nl-BE",
+        )
+        raise RuntimeError("force rollback")
+    send.assert_not_called()

--- a/tests/test_core_services_signup.py
+++ b/tests/test_core_services_signup.py
@@ -195,6 +195,32 @@ def test_verify_email_enqueued_on_commit(
 
 
 @pytest.mark.django_db
+def test_email_send_failure_does_not_break_signup(
+    django_capture_on_commit_callbacks: _Capture,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    with (
+        patch(
+            "core.services.signup.send_templated",
+            side_effect=RuntimeError("smtp down"),
+        ),
+        django_capture_on_commit_callbacks(execute=True),
+    ):
+        org, user, _ = create_organization_with_admin(
+            email="o@x.be",
+            password="hunter22",
+            org_name="X",
+            org_slug="x",
+            vat_number="BE0417710407",
+            billing_email="b@x.be",
+            default_language="nl-BE",
+        )
+    assert org.pk is not None
+    assert user.pk is not None
+    assert any("verify email send failed" in r.message for r in caplog.records)
+
+
+@pytest.mark.django_db
 def test_email_not_sent_if_transaction_rolls_back(
     django_capture_on_commit_callbacks: _Capture,
 ) -> None:


### PR DESCRIPTION
Closes #52, closes #53.

## Summary
- `create_organization_with_admin`: required `default_language` kwarg, persists `Organization.default_language` and seeds `User.preferred_language`; verify email enqueued via `transaction.on_commit` so rolled-back signups never leak email; absolute `verify_url` built from new `SITE_URL` setting + `reverse('core:verify', ...)`.
- `core/services/activation.py`: `activate_from_token` runs inside `transaction.atomic()` with `select_for_update` on user and first active ADMIN membership, flips both `is_active` flags. Raises `AlreadyActiveError` on reuse, `NoAdminMembershipError` on data anomaly. `BadSignature` / `SignatureExpired` propagate.
- Placeholder `core:verify` route (501) keeps `reverse()` resolving until the verify view ships.

## Deviations from epic 2b
- Added `SITE_URL` setting (epic doesn't mention it but absolute URLs in transactional emails are non-negotiable).
- Added `NoAdminMembershipError` as a cheap safety net even though epic assumes the case is impossible at v1 signup.
- `order_by("created_at")` on the ADMIN membership lookup so "first" is deterministic.

## Test plan
- [x] `uv run pytest tests/test_core_services_signup.py tests/test_core_services_activation.py` (15 passed, 1 skipped on SQLite for FOR UPDATE)
- [x] `uv run pytest -q` (226 passed, 1 skipped)
- [x] `uv run ruff check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)