### PR TITLE
feat(2b): public signup form + view + templates

### DIFF
--- a/core/forms/signup.py
+++ b/core/forms/signup.py
@@ -1,0 +1,70 @@
+from typing import Any
+
+from django import forms
+from django.conf import settings
+from django.contrib.auth.password_validation import validate_password
+from django.core.exceptions import ValidationError
+from django.utils.translation import gettext_lazy as _
+from django_countries.fields import CountryField
+
+from core.models import Organization, User
+from core.validators import validate_slug, validate_vat
+
+
+class SignupForm(forms.Form):
+    email = forms.EmailField(
+        label=_("Email"),
+        max_length=254,
+    )
+    password = forms.CharField(
+        label=_("Password"),
+        widget=forms.PasswordInput(render_value=False),
+        strip=False,
+    )
+    org_name = forms.CharField(
+        label=_("Organisation name"),
+        max_length=120,
+    )
+    org_slug = forms.CharField(
+        label=_("URL slug"),
+        max_length=50,
+        validators=[validate_slug],
+    )
+    vat_number = forms.CharField(
+        label=_("VAT number"),
+        max_length=14,
+    )
+    country = CountryField(default="BE").formfield(label=_("Country"))
+    default_language = forms.ChoiceField(
+        label=_("Language"),
+        choices=settings.LANGUAGES,
+    )
+
+    def clean_email(self) -> str:
+        return self.cleaned_data["email"].lower()
+
+    def clean(self) -> dict[str, Any]:
+        cleaned: dict[str, Any] = super().clean() or {}
+        vat = cleaned.get("vat_number")
+        country = cleaned.get("country")
+        if vat and country:
+            try:
+                validate_vat(vat, str(country))
+            except ValidationError as e:
+                self.add_error("vat_number", e)
+        slug = cleaned.get("org_slug")
+        if slug and Organization.objects.filter(slug=slug).exists():
+            self.add_error("org_slug", _("This slug is already taken."))
+        email = cleaned.get("email")
+        if email and User.objects.filter(email__iexact=email).exists():
+            self.add_error(
+                "email",
+                _("An account with this email already exists."),
+            )
+        password = cleaned.get("password")
+        if password and not self.has_error("password"):
+            try:
+                validate_password(password, user=User(email=email or ""))
+            except ValidationError as e:
+                self.add_error("password", e)
+        return cleaned

--- a/core/urls.py
+++ b/core/urls.py
@@ -3,13 +3,15 @@ from django.urls import path
 from django.urls.resolvers import URLPattern
 
 from .views import home
-from .views.auth import verify_placeholder
+from .views.auth import signup, signup_done, verify_placeholder
 from .views.design import design_kitchen_sink
 
 app_name = "core"
 
 urlpatterns: list[URLPattern] = [
     path(route="", view=home, name="home"),
+    path(route="signup/", view=signup, name="signup"),
+    path(route="signup/done/", view=signup_done, name="signup_done"),
     path(route="verify/<str:token>/", view=verify_placeholder, name="verify"),
 ]
 

--- a/core/views/auth.py
+++ b/core/views/auth.py
@@ -1,4 +1,51 @@
+from django.conf import settings
+from django.db import IntegrityError
 from django.http import HttpRequest, HttpResponse
+from django.shortcuts import redirect, render
+from django.utils.translation import get_language
+from django.utils.translation import gettext_lazy as _
+
+from core.forms.signup import SignupForm
+from core.services.signup import create_organization_with_admin
+
+
+def signup(request: HttpRequest) -> HttpResponse:
+    if request.user.is_authenticated:
+        return redirect(settings.LOGIN_REDIRECT_URL)
+    if request.method == "POST":
+        form = SignupForm(request.POST)
+        if form.is_valid():
+            try:
+                create_organization_with_admin(
+                    email=form.cleaned_data["email"],
+                    password=form.cleaned_data["password"],
+                    org_name=form.cleaned_data["org_name"],
+                    org_slug=form.cleaned_data["org_slug"],
+                    vat_number=form.cleaned_data["vat_number"],
+                    billing_email=form.cleaned_data["email"],
+                    default_language=form.cleaned_data["default_language"],
+                    country=str(form.cleaned_data["country"]),
+                )
+            except IntegrityError:
+                form.add_error(
+                    None,
+                    _("This email or organisation slug is already in use."),
+                )
+            else:
+                return redirect("core:signup_done")
+    else:
+        # Django normalises Accept-Language to lowercase (nl-be), but
+        # settings.LANGUAGES uses canonical case (nl-BE) which is what the
+        # form choices expect. Case-insensitive lookup bridges the two.
+        active = (get_language() or settings.LANGUAGE_CODE).lower()
+        canonical = {code.lower(): code for code, _ in settings.LANGUAGES}
+        initial_lang = canonical.get(active, settings.LANGUAGE_CODE)
+        form = SignupForm(initial={"default_language": initial_lang})
+    return render(request, "auth/signup.html", {"form": form})
+
+
+def signup_done(request: HttpRequest) -> HttpResponse:
+    return render(request, "auth/signup_done.html")
 
 
 def verify_placeholder(request: HttpRequest, token: str) -> HttpResponse:

--- a/locale/nl_BE/LC_MESSAGES/django.po
+++ b/locale/nl_BE/LC_MESSAGES/django.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: rapido\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-05-01 23:26+0000\n"
+"POT-Creation-Date: 2026-05-02 10:51+0000\n"
 "PO-Revision-Date: 2026-05-01 11:19+0000\n"
 "Language-Team: Dutch (Belgium)\n"
 "Language: nl_BE\n"
@@ -48,6 +48,50 @@ msgstr "Persoonlijke informatie"
 #: core/admin.py:250
 msgid "Permissions"
 msgstr "Rechten"
+
+#: core/forms/signup.py:16 core/views/design.py:37
+#, fuzzy
+#| msgid "email"
+msgid "Email"
+msgstr "e-mail"
+
+#: core/forms/signup.py:20
+msgid "Password"
+msgstr ""
+
+#: core/forms/signup.py:25
+#, fuzzy
+#| msgid "organization"
+msgid "Organisation name"
+msgstr "organisatie"
+
+#: core/forms/signup.py:29
+msgid "URL slug"
+msgstr ""
+
+#: core/forms/signup.py:34 core/models/organization.py:64
+msgid "VAT number"
+msgstr "btw-nummer"
+
+#: core/forms/signup.py:37
+#, fuzzy
+#| msgid "country"
+msgid "Country"
+msgstr "land"
+
+#: core/forms/signup.py:39
+#, fuzzy
+#| msgid "default language"
+msgid "Language"
+msgstr "standaardtaal"
+
+#: core/forms/signup.py:57
+msgid "This slug is already taken."
+msgstr ""
+
+#: core/forms/signup.py:62
+msgid "An account with this email already exists."
+msgstr ""
 
 #: core/models/location.py:27 core/models/membership.py:29
 #: core/models/organization.py:76
@@ -157,10 +201,6 @@ msgstr "standaardvaluta"
 msgid "default language"
 msgstr "standaardtaal"
 
-#: core/models/organization.py:64
-msgid "VAT number"
-msgstr "btw-nummer"
-
 #: core/models/organization.py:67
 msgid "billing email"
 msgstr "facturatie-e-mail"
@@ -224,6 +264,10 @@ msgstr "Ongeldige valutacode. Ondersteunde valuta's zijn: %(currencies)s."
 msgid "URL must contain only lowercase letters, digits, and hyphens."
 msgstr "URL mag alleen kleine letters, cijfers en koppeltekens bevatten."
 
+#: core/views/auth.py:32
+msgid "This email or organisation slug is already in use."
+msgstr ""
+
 #: core/views/design.py:36
 msgid "Name"
 msgstr ""
@@ -231,12 +275,6 @@ msgstr ""
 #: core/views/design.py:36
 msgid "Your full name."
 msgstr ""
-
-#: core/views/design.py:37
-#, fuzzy
-#| msgid "email"
-msgid "Email"
-msgstr "e-mail"
 
 #: core/views/design.py:39
 msgid "Role"
@@ -267,6 +305,44 @@ msgstr ""
 
 #: templates/_partials/user_menu.html:3
 msgid "Sign out"
+msgstr ""
+
+#: templates/auth/signup.html:4
+msgid "Create your account"
+msgstr ""
+
+#: templates/auth/signup.html:7
+#, fuzzy
+#| msgid "organization"
+msgid "Create your organisation"
+msgstr "organisatie"
+
+#: templates/auth/signup.html:14
+#, fuzzy
+#| msgid "URL must contain only lowercase letters, digits, and hyphens."
+msgid "Lowercase letters, numbers, and dashes."
+msgstr "URL mag alleen kleine letters, cijfers en koppeltekens bevatten."
+
+#: templates/auth/signup.html:16
+msgid "Format: BE0123456789"
+msgstr ""
+
+#: templates/auth/signup.html:20
+msgid "Create account"
+msgstr ""
+
+#: templates/auth/signup_done.html:4 templates/auth/signup_done.html:7
+msgid "Check your inbox"
+msgstr ""
+
+#: templates/auth/signup_done.html:8
+msgid ""
+"We've sent a verification link to your email. Click it to activate your "
+"account."
+msgstr ""
+
+#: templates/auth/signup_done.html:9
+msgid "The link is valid for 7 days."
 msgstr ""
 
 #: templates/base_org.html:7 templates/base_picker.html:7

--- a/templates/auth/signup.html
+++ b/templates/auth/signup.html
@@ -1,0 +1,40 @@
+{% extends "base_public.html" %}
+{% load i18n forms %}
+
+{% block title %}{% trans "Create your account" %}{% endblock %}
+
+{% block main %}
+  <h1>{% trans "Create your organisation" %}</h1>
+  <form method="post" novalidate
+        x-data="{
+          slugDirty: {% if form.org_slug.value %}true{% else %}false{% endif %},
+          slugify(s) {
+            return s.toString().toLowerCase()
+              .normalize('NFD').replace(/\p{M}/gu, '')
+              .replace(/[^a-z0-9]+/g, '-')
+              .replace(/^-+|-+$/g, '');
+          },
+          onInput(e) {
+            if (e.target.id === 'id_org_slug') { this.slugDirty = true; return; }
+            if (e.target.id === 'id_org_name' && !this.slugDirty) {
+              const slug = document.getElementById('id_org_slug');
+              if (slug) slug.value = this.slugify(e.target.value);
+            }
+          }
+        }"
+        @input="onInput">
+    {% csrf_token %}
+    {% include "forms/_errors.html" %}
+    {% field form.email %}
+    {% field form.password %}
+    {% field form.org_name %}
+    {% trans "Lowercase letters, numbers, and dashes." as slug_hint %}
+    {% field form.org_slug hint=slug_hint %}
+    {% trans "Format: BE0123456789" as vat_hint %}
+    {% field form.vat_number hint=vat_hint %}
+    {% field form.country %}
+    {% field form.default_language %}
+    {% trans "Create account" as submit_label %}
+    {% submit submit_label %}
+  </form>
+{% endblock %}

--- a/templates/auth/signup_done.html
+++ b/templates/auth/signup_done.html
@@ -1,0 +1,10 @@
+{% extends "base_public.html" %}
+{% load i18n %}
+
+{% block title %}{% trans "Check your inbox" %}{% endblock %}
+
+{% block main %}
+  <h1>{% trans "Check your inbox" %}</h1>
+  <p>{% trans "We've sent a verification link to your email. Click it to activate your account." %}</p>
+  <p>{% trans "The link is valid for 7 days." %}</p>
+{% endblock %}

--- a/tests/test_auth_signup.py
+++ b/tests/test_auth_signup.py
@@ -1,0 +1,184 @@
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+from django.conf import settings
+from django.test import Client
+from django.urls import reverse
+
+from core.models import Organization, OrganizationMembership, Role, User
+from tests.factories import OrganizationFactory, UserFactory
+
+_Capture = Any
+
+
+def _payload(**overrides: str) -> dict[str, str]:
+    base = {
+        "email": "owner@example.be",
+        "password": "Sup3rSecretPass!",
+        "org_name": "Frituur Janssens",
+        "org_slug": "frituur-janssens",
+        "vat_number": "BE0417710407",
+        "country": "BE",
+        "default_language": "en-US",
+    }
+    base.update(overrides)
+    return base
+
+
+@pytest.mark.django_db
+def test_get_renders_200() -> None:
+    client = Client()
+    response = client.get(reverse("core:signup"))
+    assert response.status_code == 200
+
+
+@pytest.mark.django_db
+def test_get_preselects_default_language_from_accept_language() -> None:
+    client = Client()
+    response = client.get(reverse("core:signup"), HTTP_ACCEPT_LANGUAGE="nl-BE")
+    assert response.status_code == 200
+    form = response.context["form"]
+    assert form.initial["default_language"] == "nl-BE"
+
+
+@pytest.mark.django_db
+def test_get_default_language_falls_back_when_unsupported() -> None:
+    client = Client()
+    response = client.get(reverse("core:signup"), HTTP_ACCEPT_LANGUAGE="ja")
+    assert response.status_code == 200
+    form = response.context["form"]
+    assert form.initial["default_language"] == settings.LANGUAGE_CODE
+
+
+@pytest.mark.django_db
+def test_post_valid_redirects_to_done_and_creates_rows(
+    django_capture_on_commit_callbacks: _Capture,
+) -> None:
+    client = Client()
+    with django_capture_on_commit_callbacks(execute=False):
+        response = client.post(reverse("core:signup"), data=_payload())
+    assert response.status_code == 302
+    assert response["Location"] == reverse("core:signup_done")
+    assert Organization.objects.count() == 1
+    assert User.objects.count() == 1
+    assert OrganizationMembership.objects.count() == 1
+    org = Organization.objects.get()
+    user = User.objects.get()
+    mem = OrganizationMembership.objects.get()
+    assert org.is_active is False
+    assert user.is_active is False
+    assert mem.is_active is True
+    assert mem.role == Role.ADMIN
+    assert org.default_language == "en-US"
+    assert user.preferred_language == "en-US"
+    assert org.billing_email == "owner@example.be"
+
+
+@pytest.mark.django_db
+def test_post_invalid_vat_returns_field_error() -> None:
+    client = Client()
+    response = client.post(
+        reverse("core:signup"),
+        data=_payload(vat_number="FR12345678901"),
+    )
+    assert response.status_code == 200
+    form = response.context["form"]
+    assert "vat_number" in form.errors
+    assert Organization.objects.count() == 0
+    assert User.objects.count() == 0
+
+
+@pytest.mark.django_db
+def test_post_invalid_slug_returns_field_error() -> None:
+    client = Client()
+    response = client.post(
+        reverse("core:signup"),
+        data=_payload(org_slug="Not A Slug!"),
+    )
+    assert response.status_code == 200
+    form = response.context["form"]
+    assert "org_slug" in form.errors
+    assert Organization.objects.count() == 0
+
+
+@pytest.mark.django_db
+def test_post_duplicate_slug_returns_form_error_not_500() -> None:
+    OrganizationFactory(slug="frituur-janssens")
+    client = Client()
+    response = client.post(reverse("core:signup"), data=_payload())
+    assert response.status_code == 200
+    form = response.context["form"]
+    assert "org_slug" in form.errors
+
+
+@pytest.mark.django_db
+def test_post_duplicate_email_returns_form_error_not_500() -> None:
+    UserFactory(email="owner@example.be")
+    client = Client()
+    response = client.post(
+        reverse("core:signup"), data=_payload(email="OWNER@example.be")
+    )
+    assert response.status_code == 200
+    form = response.context["form"]
+    assert "email" in form.errors
+
+
+@pytest.mark.django_db
+def test_post_weak_password_returns_field_error() -> None:
+    client = Client()
+    response = client.post(
+        reverse("core:signup"), data=_payload(password="123")
+    )
+    assert response.status_code == 200
+    form = response.context["form"]
+    assert "password" in form.errors
+    assert Organization.objects.count() == 0
+
+
+@pytest.mark.django_db
+def test_post_valid_enqueues_verify_email_on_commit(
+    django_capture_on_commit_callbacks: _Capture,
+) -> None:
+    client = Client()
+    with patch("core.services.signup.send_templated") as send:
+        with django_capture_on_commit_callbacks(execute=True) as callbacks:
+            response = client.post(
+                reverse("core:signup"),
+                data=_payload(default_language="nl-BE"),
+            )
+        assert response.status_code == 302
+        assert len(callbacks) == 1
+        send.assert_called_once()
+        args, kwargs = send.call_args
+        assert args == ("email/verify",)
+        assert kwargs["to"].email == "owner@example.be"
+        assert kwargs["language"] == "nl-BE"
+
+
+@pytest.mark.django_db
+def test_authenticated_user_is_redirected() -> None:
+    user = UserFactory()
+    client = Client()
+    client.force_login(user)
+    response = client.get(reverse("core:signup"))
+    assert response.status_code == 302
+    assert response["Location"] == settings.LOGIN_REDIRECT_URL
+
+
+@pytest.mark.django_db
+def test_signup_done_renders_200() -> None:
+    client = Client()
+    response = client.get(reverse("core:signup_done"))
+    assert response.status_code == 200
+
+
+@pytest.mark.django_db
+def test_email_normalized_to_lowercase() -> None:
+    client = Client()
+    response = client.post(
+        reverse("core:signup"), data=_payload(email="OWNER@Example.BE")
+    )
+    assert response.status_code == 302
+    user = User.objects.get()
+    assert user.email == "owner@example.be"


### PR DESCRIPTION
## Summary
- Wires `/signup/` to `create_organization_with_admin` per epic 2b §4: form, view, two templates, two routes.
- `SignupForm` runs VAT/country and slug-regex validation, pre-checks slug/email uniqueness for field-level errors, and runs `validate_password` against a stub `User(email=...)` so `UserAttributeSimilarityValidator` is meaningful at signup. `IntegrityError` remains the safety net.
- `default_language` preselects from `Accept-Language` via a case-insensitive match against `settings.LANGUAGES` (Django lowercases `nl-be`; our setting uses `nl-BE`).
- Slug auto-fills from organisation name via inline Alpine, locks the moment the user types directly in the slug field; bound forms with errors don't get their slug overwritten.

Closes #54.

## Test plan
- [x] `uv run pytest tests/test_auth_signup.py` — 13 tests, all green
- [x] `uv run pytest` — full suite green (240 passed, 1 skipped)
- [x] `uv run python manage.py check` — no issues
- [x] `uv run python manage.py makemessages -l nl_BE` — picks up new msgids (Email, Password, Organisation name, URL slug, VAT number, Country, Language, Lowercase letters..., Format: BE..., Create account, Check your inbox, etc.)
- [x] Manual: GET `/signup/` with `Accept-Language: nl-BE` → `default_language` selected = `nl-BE`
- [x] Manual: POST valid → 302 → `/signup/done/`; verify email visible in dev console (`EMAIL_BACKEND` = console)
- [x] Manual: type in `org_name`, watch `org_slug` autofill; type in `org_slug`, autofill stops (browser-only — verify locally)

## Out of scope (per the issue)
- `/verify/<token>/` endpoint (`verify_placeholder` still 501).
- Login view, password reset, org picker.
- Live VIES VAT lookup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)