### PR TITLE
feat(2b): verify view with auto-login + login redirect helper

### DIFF
--- a/core/services/login_redirect.py
+++ b/core/services/login_redirect.py
@@ -1,0 +1,15 @@
+from core.models import OrganizationMembership, User
+
+
+def login_redirect_for(user: User) -> str:
+    # Whitepaper epic 2b §4 redirect rule. OPERATOR with single
+    # LocationMembership -> /o/<slug>/l/<lslug>/pos/ refinement is deferred
+    # to issue #56 once the picker and POS routes exist.
+    memberships = list(
+        OrganizationMembership.objects.filter(user=user, is_active=True)
+        .select_related("organization")
+        .order_by("created_at")
+    )
+    if len(memberships) == 1:
+        return f"/o/{memberships[0].organization.slug}/"
+    return "/orgs/"

--- a/core/urls.py
+++ b/core/urls.py
@@ -3,7 +3,7 @@ from django.urls import path
 from django.urls.resolvers import URLPattern
 
 from .views import home
-from .views.auth import signup, signup_done, verify_placeholder
+from .views.auth import signup, signup_done, verify
 from .views.design import design_kitchen_sink
 
 app_name = "core"
@@ -12,7 +12,7 @@ urlpatterns: list[URLPattern] = [
     path(route="", view=home, name="home"),
     path(route="signup/", view=signup, name="signup"),
     path(route="signup/done/", view=signup_done, name="signup_done"),
-    path(route="verify/<str:token>/", view=verify_placeholder, name="verify"),
+    path(route="verify/<str:token>/", view=verify, name="verify"),
 ]
 
 if settings.DEBUG:

--- a/core/views/auth.py
+++ b/core/views/auth.py
@@ -1,4 +1,6 @@
 from django.conf import settings
+from django.contrib.auth import login
+from django.core import signing
 from django.db import IntegrityError
 from django.http import HttpRequest, HttpResponse
 from django.shortcuts import redirect, render
@@ -6,6 +8,9 @@ from django.utils.translation import get_language
 from django.utils.translation import gettext_lazy as _
 
 from core.forms.signup import SignupForm
+from core.services.activation import activate_from_token
+from core.services.exceptions import AlreadyActiveError, NoAdminMembershipError
+from core.services.login_redirect import login_redirect_for
 from core.services.signup import create_organization_with_admin
 
 
@@ -48,6 +53,13 @@ def signup_done(request: HttpRequest) -> HttpResponse:
     return render(request, "auth/signup_done.html")
 
 
-def verify_placeholder(request: HttpRequest, token: str) -> HttpResponse:
-    del request, token
-    return HttpResponse(status=501)
+def verify(request: HttpRequest, token: str) -> HttpResponse:
+    try:
+        user = activate_from_token(token)
+    except signing.BadSignature, NoAdminMembershipError:
+        # SignatureExpired is a BadSignature subclass; one catch covers both.
+        return render(request, "auth/verify_failed.html")
+    except AlreadyActiveError:
+        return render(request, "auth/verify_already.html")
+    login(request, user)
+    return redirect(login_redirect_for(user))

--- a/core/views/auth.py
+++ b/core/views/auth.py
@@ -56,8 +56,10 @@ def signup_done(request: HttpRequest) -> HttpResponse:
 def verify(request: HttpRequest, token: str) -> HttpResponse:
     try:
         user = activate_from_token(token)
-    except signing.BadSignature, NoAdminMembershipError:
+    except signing.BadSignature:
         # SignatureExpired is a BadSignature subclass; one catch covers both.
+        return render(request, "auth/verify_failed.html")
+    except NoAdminMembershipError:
         return render(request, "auth/verify_failed.html")
     except AlreadyActiveError:
         return render(request, "auth/verify_already.html")

--- a/templates/auth/verify_already.html
+++ b/templates/auth/verify_already.html
@@ -1,0 +1,10 @@
+{% extends "base_public.html" %}
+{% load i18n %}
+
+{% block title %}{% trans "Already verified" %}{% endblock %}
+
+{% block main %}
+  <h1>{% trans "Already verified" %}</h1>
+  <p>{% trans "Your email is already verified - this link has been used." %}</p>
+  <p><a href="/login/">{% trans "Sign in" %}</a></p>
+{% endblock %}

--- a/templates/auth/verify_failed.html
+++ b/templates/auth/verify_failed.html
@@ -1,0 +1,10 @@
+{% extends "base_public.html" %}
+{% load i18n %}
+
+{% block title %}{% trans "Verification link invalid" %}{% endblock %}
+
+{% block main %}
+  <h1>{% trans "Verification link invalid or expired" %}</h1>
+  <p>{% trans "This verification link can't be used. It may have expired (links are valid for 7 days), been tampered with, or already replaced by a newer one." %}</p>
+  <p><a href="/login/">{% trans "Sign in" %}</a> {% trans "to request a new verification email." %}</p>
+{% endblock %}

--- a/tests/test_auth_verify.py
+++ b/tests/test_auth_verify.py
@@ -1,0 +1,133 @@
+from unittest.mock import patch
+
+import pytest
+from django.contrib.auth import get_user
+from django.core import signing
+from django.test import Client
+from django.urls import reverse
+
+from core.models import Role
+from core.services.tokens import VERIFY_SALT, make_token
+from tests.factories import (
+    OrganizationFactory,
+    OrganizationMembershipFactory,
+    UserFactory,
+)
+
+
+@pytest.mark.django_db
+def test_valid_token_activates_logs_in_and_redirects() -> None:
+    user = UserFactory(is_active=False)
+    org = OrganizationFactory(is_active=False, slug="frituur-janssens")
+    OrganizationMembershipFactory(user=user, organization=org, role=Role.ADMIN)
+    token = make_token(user, salt=VERIFY_SALT)
+    client = Client()
+
+    response = client.get(reverse("core:verify", args=[token]))
+
+    assert response.status_code == 302
+    assert response["Location"] == "/o/frituur-janssens/"
+    user.refresh_from_db()
+    org.refresh_from_db()
+    assert user.is_active is True
+    assert org.is_active is True
+    auth_user = get_user(client)
+    assert auth_user.is_authenticated
+    assert auth_user.pk == user.pk
+
+
+@pytest.mark.django_db
+def test_tampered_token_renders_failed_no_state_change() -> None:
+    user = UserFactory(is_active=False)
+    org = OrganizationFactory(is_active=False)
+    OrganizationMembershipFactory(user=user, organization=org, role=Role.ADMIN)
+    client = Client()
+
+    response = client.get(reverse("core:verify", args=["not-a-token"]))
+
+    assert response.status_code == 200
+    assert "auth/verify_failed.html" in [t.name for t in response.templates]
+    user.refresh_from_db()
+    org.refresh_from_db()
+    assert user.is_active is False
+    assert org.is_active is False
+    auth_user = get_user(client)
+    assert not auth_user.is_authenticated
+
+
+@pytest.mark.django_db
+def test_expired_token_renders_failed() -> None:
+    user = UserFactory(is_active=False)
+    org = OrganizationFactory(is_active=False)
+    OrganizationMembershipFactory(user=user, organization=org, role=Role.ADMIN)
+    token = make_token(user, salt=VERIFY_SALT)
+    client = Client()
+
+    with patch(
+        "core.services.activation.verify_token",
+        side_effect=signing.SignatureExpired("expired"),
+    ):
+        response = client.get(reverse("core:verify", args=[token]))
+
+    assert response.status_code == 200
+    assert "auth/verify_failed.html" in [t.name for t in response.templates]
+    user.refresh_from_db()
+    assert user.is_active is False
+
+
+@pytest.mark.django_db
+def test_second_click_renders_already() -> None:
+    user = UserFactory(is_active=False)
+    org = OrganizationFactory(is_active=False)
+    OrganizationMembershipFactory(user=user, organization=org, role=Role.ADMIN)
+    token = make_token(user, salt=VERIFY_SALT)
+    client = Client()
+
+    first = client.get(reverse("core:verify", args=[token]))
+    assert first.status_code == 302
+
+    # Fresh client so the active session doesn't influence the second click.
+    second_client = Client()
+    second = second_client.get(reverse("core:verify", args=[token]))
+
+    assert second.status_code == 200
+    assert "auth/verify_already.html" in [t.name for t in second.templates]
+
+
+@pytest.mark.django_db
+def test_no_active_admin_membership_renders_failed() -> None:
+    user = UserFactory(is_active=False)
+    org = OrganizationFactory(is_active=False)
+    OrganizationMembershipFactory(
+        user=user, organization=org, role=Role.OPERATOR
+    )
+    token = make_token(user, salt=VERIFY_SALT)
+    client = Client()
+
+    response = client.get(reverse("core:verify", args=[token]))
+
+    assert response.status_code == 200
+    assert "auth/verify_failed.html" in [t.name for t in response.templates]
+    user.refresh_from_db()
+    assert user.is_active is False
+
+
+@pytest.mark.django_db
+def test_authenticated_other_user_session_swaps_to_activated_user() -> None:
+    other = UserFactory()
+    user = UserFactory(is_active=False)
+    org = OrganizationFactory(is_active=False, slug="acme")
+    OrganizationMembershipFactory(user=user, organization=org, role=Role.ADMIN)
+    token = make_token(user, salt=VERIFY_SALT)
+    client = Client()
+    client.force_login(other)
+
+    response = client.get(reverse("core:verify", args=[token]))
+
+    assert response.status_code == 302
+    assert response["Location"] == "/o/acme/"
+    user.refresh_from_db()
+    assert user.is_active is True
+    auth_user = get_user(client)
+    assert auth_user.is_authenticated
+    assert auth_user.pk == user.pk

--- a/tests/test_core_services_login_redirect.py
+++ b/tests/test_core_services_login_redirect.py
@@ -1,0 +1,51 @@
+import pytest
+
+from core.models import Role
+from core.services.login_redirect import login_redirect_for
+from tests.factories import (
+    OrganizationFactory,
+    OrganizationMembershipFactory,
+    UserFactory,
+)
+
+
+@pytest.mark.django_db
+def test_single_active_membership_returns_org_url() -> None:
+    user = UserFactory()
+    org = OrganizationFactory(slug="acme")
+    OrganizationMembershipFactory(user=user, organization=org, role=Role.ADMIN)
+    assert login_redirect_for(user) == "/o/acme/"
+
+
+@pytest.mark.django_db
+def test_multiple_active_memberships_returns_picker() -> None:
+    user = UserFactory()
+    OrganizationMembershipFactory(user=user, role=Role.ADMIN)
+    OrganizationMembershipFactory(user=user, role=Role.ADMIN)
+    assert login_redirect_for(user) == "/orgs/"
+
+
+@pytest.mark.django_db
+def test_no_membership_returns_picker() -> None:
+    user = UserFactory()
+    assert login_redirect_for(user) == "/orgs/"
+
+
+@pytest.mark.django_db
+def test_inactive_membership_excluded() -> None:
+    user = UserFactory()
+    inactive_org = OrganizationFactory(slug="inactive")
+    OrganizationMembershipFactory(
+        user=user,
+        organization=inactive_org,
+        role=Role.ADMIN,
+        is_active=False,
+    )
+    active_org = OrganizationFactory(slug="active")
+    OrganizationMembershipFactory(
+        user=user,
+        organization=active_org,
+        role=Role.ADMIN,
+        is_active=True,
+    )
+    assert login_redirect_for(user) == "/o/active/"


### PR DESCRIPTION
## Summary
- Replace `/verify/<token>/` placeholder with the real view: activates user + org via `activate_from_token`, auto-logs in, and redirects per whitepaper §4.
- New helper `core/services/login_redirect.py:login_redirect_for(user)` (reusable by login #56 and password-reset #57).
- New templates `auth/verify_failed.html` and `auth/verify_already.html`.

## Decisions worth flagging
- `NoAdminMembershipError` lands on `verify_failed.html` (issue didn't list it; defensive vs 500).
- Authenticated user clicking a fresh `/verify/<token>/` still processes the token - `auth.login()` swaps the session.
- `verify_done.html` skipped: success path always 302s, no code path renders it.
- `OPERATOR + single LocationMembership -> .../pos/` refinement deferred to #56 (POS routes don't exist yet); helper handles single/multi/zero membership.

Closes #55.

## Test plan
- [x] `uv run pytest tests/test_auth_verify.py tests/test_core_services_login_redirect.py` (10 new tests green)
- [x] `uv run pytest` (250 passed, 1 skipped - no regressions)
- [x] `uv run ruff check` + `uv run pyright` clean
- [x] End-to-end smoke via Playwright on dev server: signup -> console email token -> 302 to `/o/<slug>/` (404 expected, route lands in 2c), DB confirms both `is_active` flags True, second click -> `verify_already.html`, garbage token -> `verify_failed.html`

🤖 Generated with [Claude Code](https://claude.com/claude-code)