### PR TITLE
feat(2b): login + logout + post-login redirect chain (#56)

### DIFF
--- a/core/forms/auth.py
+++ b/core/forms/auth.py
@@ -1,0 +1,51 @@
+from typing import Any
+
+from django import forms
+from django.core.exceptions import ValidationError
+from django.utils.translation import gettext_lazy as _
+
+from core.models import User
+
+
+class LoginForm(forms.Form):
+    email = forms.EmailField(
+        label=_("Email"),
+        max_length=254,
+    )
+    password = forms.CharField(
+        label=_("Password"),
+        widget=forms.PasswordInput(render_value=False),
+        strip=False,
+    )
+
+    # Class-level defaults; clean() rebinds them as instance attributes.
+    user_cache: User | None = None
+    # Set when password is correct but the account is unverified; the
+    # template renders the resend form only when this is truthy.
+    unverified_email: str | None = None
+
+    def clean_email(self) -> str:
+        return (self.cleaned_data.get("email") or "").lower().strip()
+
+    def clean(self) -> dict[str, Any]:
+        cleaned: dict[str, Any] = super().clean() or {}
+        email = cleaned.get("email")
+        password = cleaned.get("password")
+        if not (email and password):
+            return cleaned
+        user = User.objects.filter(email__iexact=email).first()
+        if user is None or not user.check_password(password):
+            raise ValidationError(_("Invalid email or password."))
+        if not user.is_active:
+            self.unverified_email = email
+            raise ValidationError(
+                _(
+                    "Your email isn't verified yet. Check your inbox for the "
+                    "verification link."
+                )
+            )
+        self.user_cache = user
+        return cleaned
+
+    def get_user(self) -> User | None:
+        return self.user_cache

--- a/core/services/login_redirect.py
+++ b/core/services/login_redirect.py
@@ -1,15 +1,31 @@
-from core.models import OrganizationMembership, User
+from core.models import LocationMembership, OrganizationMembership, Role, User
 
 
 def login_redirect_for(user: User) -> str:
-    # Whitepaper epic 2b §4 redirect rule. OPERATOR with single
-    # LocationMembership -> /o/<slug>/l/<lslug>/pos/ refinement is deferred
-    # to issue #56 once the picker and POS routes exist.
+    # Whitepaper epic 2b §4 redirect rule:
+    #   single active org membership -> /o/<slug>/
+    #   OPERATOR with exactly one active LocationMembership in that org
+    #     -> /o/<slug>/l/<lslug>/pos/ (route reserved; 404 until POS epic)
+    #   anything else (zero or multiple orgs) -> /orgs/
     memberships = list(
         OrganizationMembership.objects.filter(user=user, is_active=True)
         .select_related("organization")
         .order_by("created_at")
     )
-    if len(memberships) == 1:
-        return f"/o/{memberships[0].organization.slug}/"
-    return "/orgs/"
+    if len(memberships) != 1:
+        return "/orgs/"
+    mem = memberships[0]
+    org_slug = mem.organization.slug
+    if mem.role == Role.OPERATOR:
+        loc_memberships = list(
+            LocationMembership.objects.filter(
+                user=user,
+                is_active=True,
+                location__organization=mem.organization,
+            )
+            .select_related("location")
+            .order_by("created_at")[:2]
+        )
+        if len(loc_memberships) == 1:
+            return f"/o/{org_slug}/l/{loc_memberships[0].location.slug}/pos/"
+    return f"/o/{org_slug}/"

--- a/core/services/resend.py
+++ b/core/services/resend.py
@@ -1,3 +1,5 @@
+import logging
+
 from django.conf import settings
 from django.db import transaction
 from django.urls import reverse
@@ -5,6 +7,25 @@ from django.urls import reverse
 from core.models import OrganizationMembership, Role, User
 from core.services.mail import send_templated
 from core.services.tokens import VERIFY_SALT, make_token
+
+logger = logging.getLogger(__name__)
+
+
+def _send_verify_email(
+    *, user: User, language: str | None, verify_url: str, org_name: str
+) -> None:
+    # Best-effort. Swallowing keeps the resend view idempotent: an SMTP /
+    # template failure must not turn the inactive-user branch into a 500
+    # while active/missing emails still return 200 (would leak existence).
+    try:
+        send_templated(
+            "email/verify",
+            to=user,
+            language=language,
+            context={"verify_url": verify_url, "org_name": org_name},
+        )
+    except Exception:
+        logger.exception("resend verify email failed for user_id=%s", user.pk)
 
 
 def resend_verification_email(email: str) -> None:
@@ -30,10 +51,10 @@ def resend_verification_email(email: str) -> None:
     token = make_token(user, salt=VERIFY_SALT)
     verify_url = f"{settings.SITE_URL}{reverse('core:verify', args=[token])}"
     transaction.on_commit(
-        lambda: send_templated(
-            "email/verify",
-            to=user,
+        lambda: _send_verify_email(
+            user=user,
             language=language,
-            context={"verify_url": verify_url, "org_name": org_name},
+            verify_url=verify_url,
+            org_name=org_name,
         )
     )

--- a/core/services/resend.py
+++ b/core/services/resend.py
@@ -1,0 +1,39 @@
+from django.conf import settings
+from django.db import transaction
+from django.urls import reverse
+
+from core.models import OrganizationMembership, Role, User
+from core.services.mail import send_templated
+from core.services.tokens import VERIFY_SALT, make_token
+
+
+def resend_verification_email(email: str) -> None:
+    # Idempotent: looks up an inactive user by case-insensitive email and
+    # enqueues a fresh verify email on commit. No-op for active, missing,
+    # or empty inputs so the caller can always render the same "sent"
+    # response without enumerating accounts (whitepaper epic 2b §3).
+    if not email:
+        return
+    user = User.objects.filter(email__iexact=email, is_active=False).first()
+    if user is None:
+        return
+    mem = (
+        OrganizationMembership.objects.filter(
+            user=user, role=Role.ADMIN, is_active=True
+        )
+        .select_related("organization")
+        .order_by("created_at")
+        .first()
+    )
+    org_name = mem.organization.name if mem else ""
+    language = mem.organization.default_language if mem else None
+    token = make_token(user, salt=VERIFY_SALT)
+    verify_url = f"{settings.SITE_URL}{reverse('core:verify', args=[token])}"
+    transaction.on_commit(
+        lambda: send_templated(
+            "email/verify",
+            to=user,
+            language=language,
+            context={"verify_url": verify_url, "org_name": org_name},
+        )
+    )

--- a/core/urls.py
+++ b/core/urls.py
@@ -3,7 +3,14 @@ from django.urls import path
 from django.urls.resolvers import URLPattern
 
 from .views import home
-from .views.auth import signup, signup_done, verify
+from .views.auth import (
+    login,
+    logout,
+    resend_verification,
+    signup,
+    signup_done,
+    verify,
+)
 from .views.design import design_kitchen_sink
 
 app_name = "core"
@@ -13,6 +20,13 @@ urlpatterns: list[URLPattern] = [
     path(route="signup/", view=signup, name="signup"),
     path(route="signup/done/", view=signup_done, name="signup_done"),
     path(route="verify/<str:token>/", view=verify, name="verify"),
+    path(route="login/", view=login, name="login"),
+    path(route="logout/", view=logout, name="logout"),
+    path(
+        route="resend-verification/",
+        view=resend_verification,
+        name="resend_verification",
+    ),
 ]
 
 if settings.DEBUG:

--- a/core/views/auth.py
+++ b/core/views/auth.py
@@ -1,16 +1,24 @@
+from typing import cast
+
 from django.conf import settings
-from django.contrib.auth import login
+from django.contrib.auth import login as auth_login
+from django.contrib.auth import logout as auth_logout
 from django.core import signing
 from django.db import IntegrityError
 from django.http import HttpRequest, HttpResponse
 from django.shortcuts import redirect, render
+from django.utils.http import url_has_allowed_host_and_scheme
 from django.utils.translation import get_language
 from django.utils.translation import gettext_lazy as _
+from django.views.decorators.http import require_POST
 
+from core.forms.auth import LoginForm
 from core.forms.signup import SignupForm
+from core.models import User
 from core.services.activation import activate_from_token
 from core.services.exceptions import AlreadyActiveError, NoAdminMembershipError
 from core.services.login_redirect import login_redirect_for
+from core.services.resend import resend_verification_email
 from core.services.signup import create_organization_with_admin
 
 
@@ -63,5 +71,46 @@ def verify(request: HttpRequest, token: str) -> HttpResponse:
         return render(request, "auth/verify_failed.html")
     except AlreadyActiveError:
         return render(request, "auth/verify_already.html")
-    login(request, user)
+    auth_login(request, user)
     return redirect(login_redirect_for(user))
+
+
+def login(request: HttpRequest) -> HttpResponse:
+    if request.user.is_authenticated:
+        return redirect(login_redirect_for(cast(User, request.user)))
+    next_param = request.POST.get("next") or request.GET.get("next") or ""
+    if request.method == "POST":
+        form = LoginForm(request.POST)
+        if form.is_valid():
+            user = form.get_user()
+            assert user is not None  # form invariant when is_valid()
+            auth_login(request, user)
+            if next_param and url_has_allowed_host_and_scheme(
+                next_param,
+                allowed_hosts={request.get_host()},
+                require_https=request.is_secure(),
+            ):
+                return redirect(next_param)
+            return redirect(login_redirect_for(user))
+    else:
+        form = LoginForm()
+    return render(
+        request,
+        "auth/login.html",
+        {"form": form, "next": next_param},
+    )
+
+
+@require_POST
+def logout(request: HttpRequest) -> HttpResponse:
+    auth_logout(request)
+    return redirect(settings.LOGOUT_REDIRECT_URL)
+
+
+@require_POST
+def resend_verification(request: HttpRequest) -> HttpResponse:
+    # Always renders the same "sent" page so the response can't be used to
+    # enumerate accounts (whitepaper epic 2b §3, issue #56 acceptance).
+    email = (request.POST.get("email") or "").strip().lower()
+    resend_verification_email(email)
+    return render(request, "auth/verify_resent.html")

--- a/templates/auth/login.html
+++ b/templates/auth/login.html
@@ -1,0 +1,27 @@
+{% extends "base_public.html" %}
+{% load i18n forms %}
+
+{% block title %}{% trans "Sign in" %}{% endblock %}
+
+{% block main %}
+  <h1>{% trans "Sign in" %}</h1>
+  <form method="post" novalidate>
+    {% csrf_token %}
+    {% if next %}<input type="hidden" name="next" value="{{ next }}">{% endif %}
+    {% include "forms/_errors.html" %}
+    {% field form.email %}
+    {% field form.password %}
+    {% trans "Sign in" as submit_label %}
+    {% submit submit_label %}
+  </form>
+
+  {% if form.unverified_email %}
+    <form method="post" action="{% url 'core:resend_verification' %}">
+      {% csrf_token %}
+      <input type="hidden" name="email" value="{{ form.unverified_email }}">
+      <button type="submit">{% trans "Resend verification email" %}</button>
+    </form>
+  {% endif %}
+
+  <p><a href="{% url 'core:signup' %}">{% trans "Create an account" %}</a></p>
+{% endblock %}

--- a/templates/auth/verify_resent.html
+++ b/templates/auth/verify_resent.html
@@ -1,0 +1,9 @@
+{% extends "base_public.html" %}
+{% load i18n %}
+
+{% block title %}{% trans "Check your inbox" %}{% endblock %}
+
+{% block main %}
+  <h1>{% trans "Check your inbox" %}</h1>
+  <p>{% trans "If an unverified account exists for that email, we've sent a fresh verification link." %}</p>
+{% endblock %}

--- a/tests/test_auth_login_redirect.py
+++ b/tests/test_auth_login_redirect.py
@@ -1,0 +1,419 @@
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+from django.contrib.auth import get_user
+from django.test import Client
+from django.urls import reverse
+
+from core.models import Role, User
+from tests.factories import (
+    LocationFactory,
+    LocationMembershipFactory,
+    OrganizationFactory,
+    OrganizationMembershipFactory,
+    UserFactory,
+)
+
+_Capture = Any
+
+
+# ---------------------------------------------------------------------------
+# GET /login/
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_get_renders_200() -> None:
+    client = Client()
+    response = client.get(reverse("core:login"))
+    assert response.status_code == 200
+
+
+@pytest.mark.django_db
+def test_get_authenticated_redirects_via_rule() -> None:
+    user = UserFactory()
+    org = OrganizationFactory(slug="acme")
+    OrganizationMembershipFactory(user=user, organization=org, role=Role.ADMIN)
+    client = Client()
+    client.force_login(user)
+
+    response = client.get(reverse("core:login"))
+
+    assert response.status_code == 302
+    assert response["Location"] == "/o/acme/"
+
+
+# ---------------------------------------------------------------------------
+# POST /login/ - happy paths via the redirect rule
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_post_single_admin_redirects_to_org_dashboard() -> None:
+    user = UserFactory(email="admin@example.be")
+    org = OrganizationFactory(slug="acme")
+    OrganizationMembershipFactory(user=user, organization=org, role=Role.ADMIN)
+    client = Client()
+
+    response = client.post(
+        reverse("core:login"),
+        data={"email": "admin@example.be", "password": "password"},
+    )
+
+    assert response.status_code == 302
+    assert response["Location"] == "/o/acme/"
+    auth_user = get_user(client)
+    assert auth_user.is_authenticated
+    assert auth_user.pk == user.pk
+
+
+@pytest.mark.django_db
+def test_post_multiple_memberships_redirects_to_picker() -> None:
+    user = UserFactory(email="multi@example.be")
+    OrganizationMembershipFactory(user=user, role=Role.ADMIN)
+    OrganizationMembershipFactory(user=user, role=Role.ADMIN)
+    client = Client()
+
+    response = client.post(
+        reverse("core:login"),
+        data={"email": "multi@example.be", "password": "password"},
+    )
+
+    assert response.status_code == 302
+    assert response["Location"] == "/orgs/"
+
+
+@pytest.mark.django_db
+def test_post_operator_single_location_redirects_to_pos() -> None:
+    user = UserFactory(email="op@example.be")
+    org = OrganizationFactory(slug="acme")
+    OrganizationMembershipFactory(
+        user=user, organization=org, role=Role.OPERATOR
+    )
+    location = LocationFactory(organization=org, slug="downtown")
+    LocationMembershipFactory(user=user, location=location)
+    client = Client()
+
+    response = client.post(
+        reverse("core:login"),
+        data={"email": "op@example.be", "password": "password"},
+    )
+
+    assert response.status_code == 302
+    assert response["Location"] == "/o/acme/l/downtown/pos/"
+
+
+@pytest.mark.django_db
+def test_post_operator_multiple_locations_redirects_to_org() -> None:
+    user = UserFactory(email="op2@example.be")
+    org = OrganizationFactory(slug="acme")
+    OrganizationMembershipFactory(
+        user=user, organization=org, role=Role.OPERATOR
+    )
+    LocationMembershipFactory(
+        user=user, location=LocationFactory(organization=org)
+    )
+    LocationMembershipFactory(
+        user=user, location=LocationFactory(organization=org)
+    )
+    client = Client()
+
+    response = client.post(
+        reverse("core:login"),
+        data={"email": "op2@example.be", "password": "password"},
+    )
+
+    assert response.status_code == 302
+    assert response["Location"] == "/o/acme/"
+
+
+@pytest.mark.django_db
+def test_post_operator_no_locations_redirects_to_org() -> None:
+    user = UserFactory(email="op3@example.be")
+    org = OrganizationFactory(slug="acme")
+    OrganizationMembershipFactory(
+        user=user, organization=org, role=Role.OPERATOR
+    )
+    client = Client()
+
+    response = client.post(
+        reverse("core:login"),
+        data={"email": "op3@example.be", "password": "password"},
+    )
+
+    assert response.status_code == 302
+    assert response["Location"] == "/o/acme/"
+
+
+# ---------------------------------------------------------------------------
+# POST /login/ - rejection paths (no enumeration)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_post_unknown_email_returns_generic_error() -> None:
+    client = Client()
+    response = client.post(
+        reverse("core:login"),
+        data={"email": "nobody@example.be", "password": "password"},
+    )
+
+    assert response.status_code == 200
+    form = response.context["form"]
+    assert "Invalid email or password" in str(form.non_field_errors())
+    assert form.unverified_email is None
+    assert reverse("core:resend_verification").encode() not in response.content
+
+
+@pytest.mark.django_db
+def test_post_wrong_password_returns_generic_error() -> None:
+    UserFactory(email="user@example.be")
+    client = Client()
+    response = client.post(
+        reverse("core:login"),
+        data={"email": "user@example.be", "password": "wrong"},
+    )
+
+    assert response.status_code == 200
+    form = response.context["form"]
+    assert "Invalid email or password" in str(form.non_field_errors())
+    assert form.unverified_email is None
+    assert reverse("core:resend_verification").encode() not in response.content
+
+
+@pytest.mark.django_db
+def test_post_inactive_user_shows_resend() -> None:
+    user = UserFactory(email="pending@example.be", is_active=False)
+    OrganizationMembershipFactory(user=user, role=Role.ADMIN)
+    client = Client()
+
+    response = client.post(
+        reverse("core:login"),
+        data={"email": "pending@example.be", "password": "password"},
+    )
+
+    assert response.status_code == 200
+    form = response.context["form"]
+    assert form.unverified_email == "pending@example.be"
+    assert "check your inbox" in str(form.non_field_errors()).lower()
+    assert reverse("core:resend_verification").encode() in response.content
+    auth_user = get_user(client)
+    assert not auth_user.is_authenticated
+
+
+@pytest.mark.django_db
+def test_post_email_normalized_lowercase() -> None:
+    user = UserFactory(email="case@example.be")
+    org = OrganizationFactory(slug="acme")
+    OrganizationMembershipFactory(user=user, organization=org, role=Role.ADMIN)
+    client = Client()
+
+    response = client.post(
+        reverse("core:login"),
+        data={"email": "CASE@Example.BE", "password": "password"},
+    )
+
+    assert response.status_code == 302
+    assert response["Location"] == "/o/acme/"
+
+
+# ---------------------------------------------------------------------------
+# ?next= handling
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_post_safe_next_overrides_redirect_rule() -> None:
+    user = UserFactory(email="admin@example.be")
+    org = OrganizationFactory(slug="acme")
+    OrganizationMembershipFactory(user=user, organization=org, role=Role.ADMIN)
+    client = Client()
+
+    response = client.post(
+        reverse("core:login"),
+        data={
+            "email": "admin@example.be",
+            "password": "password",
+            "next": "/o/acme/menu/",
+        },
+    )
+
+    assert response.status_code == 302
+    assert response["Location"] == "/o/acme/menu/"
+
+
+@pytest.mark.django_db
+def test_post_unsafe_next_falls_through_to_rule() -> None:
+    user = UserFactory(email="admin@example.be")
+    org = OrganizationFactory(slug="acme")
+    OrganizationMembershipFactory(user=user, organization=org, role=Role.ADMIN)
+    client = Client()
+
+    response = client.post(
+        reverse("core:login"),
+        data={
+            "email": "admin@example.be",
+            "password": "password",
+            "next": "https://evil.example.com/",
+        },
+    )
+
+    assert response.status_code == 302
+    assert response["Location"] == "/o/acme/"
+
+
+@pytest.mark.django_db
+def test_get_with_next_renders_hidden_input() -> None:
+    client = Client()
+    response = client.get(reverse("core:login") + "?next=/o/acme/menu/")
+
+    assert response.status_code == 200
+    assert response.context["next"] == "/o/acme/menu/"
+    assert b'name="next"' in response.content
+    assert b"/o/acme/menu/" in response.content
+
+
+# ---------------------------------------------------------------------------
+# /logout/
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_logout_post_clears_session_and_redirects() -> None:
+    user = UserFactory()
+    client = Client()
+    client.force_login(user)
+    assert get_user(client).is_authenticated
+
+    response = client.post(reverse("core:logout"))
+
+    assert response.status_code == 302
+    assert response["Location"] == "/"
+    assert not get_user(client).is_authenticated
+
+
+@pytest.mark.django_db
+def test_logout_get_returns_405() -> None:
+    user = UserFactory()
+    client = Client()
+    client.force_login(user)
+
+    response = client.get(reverse("core:logout"))
+
+    assert response.status_code == 405
+    assert get_user(client).is_authenticated
+
+
+@pytest.mark.django_db
+def test_logout_anonymous_post_is_idempotent() -> None:
+    client = Client()
+    response = client.post(reverse("core:logout"))
+
+    assert response.status_code == 302
+    assert response["Location"] == "/"
+
+
+# ---------------------------------------------------------------------------
+# /resend-verification/
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_resend_inactive_user_enqueues_email(
+    django_capture_on_commit_callbacks: _Capture,
+) -> None:
+    user = UserFactory(email="pending@example.be", is_active=False)
+    OrganizationMembershipFactory(user=user, role=Role.ADMIN)
+    client = Client()
+
+    with patch("core.services.resend.send_templated") as send:
+        with django_capture_on_commit_callbacks(execute=True) as callbacks:
+            response = client.post(
+                reverse("core:resend_verification"),
+                data={"email": "pending@example.be"},
+            )
+        assert response.status_code == 200
+        assert "auth/verify_resent.html" in [t.name for t in response.templates]
+        assert len(callbacks) == 1
+        send.assert_called_once()
+        args, kwargs = send.call_args
+        assert args == ("email/verify",)
+        assert kwargs["to"].pk == user.pk
+        assert kwargs["context"]["verify_url"].startswith("http")
+
+
+@pytest.mark.django_db
+def test_resend_active_user_no_email(
+    django_capture_on_commit_callbacks: _Capture,
+) -> None:
+    UserFactory(email="active@example.be", is_active=True)
+    client = Client()
+
+    with patch("core.services.resend.send_templated") as send:
+        with django_capture_on_commit_callbacks(execute=True) as callbacks:
+            response = client.post(
+                reverse("core:resend_verification"),
+                data={"email": "active@example.be"},
+            )
+        assert response.status_code == 200
+        assert "auth/verify_resent.html" in [t.name for t in response.templates]
+        assert len(callbacks) == 0
+        send.assert_not_called()
+
+
+@pytest.mark.django_db
+def test_resend_unknown_email_no_email(
+    django_capture_on_commit_callbacks: _Capture,
+) -> None:
+    client = Client()
+    with patch("core.services.resend.send_templated") as send:
+        with django_capture_on_commit_callbacks(execute=True) as callbacks:
+            response = client.post(
+                reverse("core:resend_verification"),
+                data={"email": "nobody@example.be"},
+            )
+        assert response.status_code == 200
+        assert "auth/verify_resent.html" in [t.name for t in response.templates]
+        assert len(callbacks) == 0
+        send.assert_not_called()
+
+
+@pytest.mark.django_db
+def test_resend_missing_email_no_email(
+    django_capture_on_commit_callbacks: _Capture,
+) -> None:
+    client = Client()
+    with patch("core.services.resend.send_templated") as send:
+        with django_capture_on_commit_callbacks(execute=True) as callbacks:
+            response = client.post(reverse("core:resend_verification"))
+        assert response.status_code == 200
+        assert len(callbacks) == 0
+        send.assert_not_called()
+
+
+@pytest.mark.django_db
+def test_resend_get_returns_405() -> None:
+    client = Client()
+    response = client.get(reverse("core:resend_verification"))
+    assert response.status_code == 405
+
+
+@pytest.mark.django_db
+def test_resend_case_insensitive_email_match(
+    django_capture_on_commit_callbacks: _Capture,
+) -> None:
+    UserFactory(email="pending@example.be", is_active=False)
+    client = Client()
+
+    with patch("core.services.resend.send_templated") as send:
+        with django_capture_on_commit_callbacks(execute=True):
+            response = client.post(
+                reverse("core:resend_verification"),
+                data={"email": "PENDING@Example.BE"},
+            )
+        assert response.status_code == 200
+        send.assert_called_once()
+        sent_to = send.call_args.kwargs["to"]
+        assert isinstance(sent_to, User)
+        assert sent_to.email == "pending@example.be"

--- a/tests/test_auth_login_redirect.py
+++ b/tests/test_auth_login_redirect.py
@@ -400,6 +400,30 @@ def test_resend_get_returns_405() -> None:
 
 
 @pytest.mark.django_db
+def test_resend_swallows_send_failure_to_avoid_enumeration(
+    django_capture_on_commit_callbacks: _Capture,
+) -> None:
+    # Mail backend / template failures must not turn the inactive-user
+    # branch into a 500 - active/missing emails still return 200 and a
+    # divergent response would leak account existence.
+    user = UserFactory(email="pending@example.be", is_active=False)
+    OrganizationMembershipFactory(user=user, role=Role.ADMIN)
+    client = Client()
+
+    with patch(
+        "core.services.resend.send_templated",
+        side_effect=RuntimeError("smtp down"),
+    ):
+        with django_capture_on_commit_callbacks(execute=True):
+            response = client.post(
+                reverse("core:resend_verification"),
+                data={"email": "pending@example.be"},
+            )
+        assert response.status_code == 200
+        assert "auth/verify_resent.html" in [t.name for t in response.templates]
+
+
+@pytest.mark.django_db
 def test_resend_case_insensitive_email_match(
     django_capture_on_commit_callbacks: _Capture,
 ) -> None:

--- a/tests/test_core_services_login_redirect.py
+++ b/tests/test_core_services_login_redirect.py
@@ -3,6 +3,8 @@ import pytest
 from core.models import Role
 from core.services.login_redirect import login_redirect_for
 from tests.factories import (
+    LocationFactory,
+    LocationMembershipFactory,
     OrganizationFactory,
     OrganizationMembershipFactory,
     UserFactory,
@@ -49,3 +51,72 @@ def test_inactive_membership_excluded() -> None:
         is_active=True,
     )
     assert login_redirect_for(user) == "/o/active/"
+
+
+@pytest.mark.django_db
+def test_admin_with_single_location_membership_still_lands_on_org() -> None:
+    # Whitepaper §1: only OPERATOR triggers the POS shortcut.
+    user = UserFactory()
+    org = OrganizationFactory(slug="acme")
+    OrganizationMembershipFactory(user=user, organization=org, role=Role.ADMIN)
+    LocationMembershipFactory(
+        user=user, location=LocationFactory(organization=org)
+    )
+    assert login_redirect_for(user) == "/o/acme/"
+
+
+@pytest.mark.django_db
+def test_operator_single_location_returns_pos_url() -> None:
+    user = UserFactory()
+    org = OrganizationFactory(slug="acme")
+    OrganizationMembershipFactory(
+        user=user, organization=org, role=Role.OPERATOR
+    )
+    location = LocationFactory(organization=org, slug="downtown")
+    LocationMembershipFactory(user=user, location=location)
+    assert login_redirect_for(user) == "/o/acme/l/downtown/pos/"
+
+
+@pytest.mark.django_db
+def test_operator_multiple_locations_returns_org_url() -> None:
+    user = UserFactory()
+    org = OrganizationFactory(slug="acme")
+    OrganizationMembershipFactory(
+        user=user, organization=org, role=Role.OPERATOR
+    )
+    LocationMembershipFactory(
+        user=user, location=LocationFactory(organization=org)
+    )
+    LocationMembershipFactory(
+        user=user, location=LocationFactory(organization=org)
+    )
+    assert login_redirect_for(user) == "/o/acme/"
+
+
+@pytest.mark.django_db
+def test_operator_zero_locations_returns_org_url() -> None:
+    user = UserFactory()
+    org = OrganizationFactory(slug="acme")
+    OrganizationMembershipFactory(
+        user=user, organization=org, role=Role.OPERATOR
+    )
+    assert login_redirect_for(user) == "/o/acme/"
+
+
+@pytest.mark.django_db
+def test_operator_inactive_location_membership_ignored() -> None:
+    # Inactive LocationMembership doesn't count toward the "exactly one" branch.
+    user = UserFactory()
+    org = OrganizationFactory(slug="acme")
+    OrganizationMembershipFactory(
+        user=user, organization=org, role=Role.OPERATOR
+    )
+    LocationMembershipFactory(
+        user=user,
+        location=LocationFactory(organization=org),
+        is_active=False,
+    )
+    LocationMembershipFactory(
+        user=user, location=LocationFactory(organization=org, slug="active-loc")
+    )
+    assert login_redirect_for(user) == "/o/acme/l/active-loc/pos/"


### PR DESCRIPTION
## Summary
- Adds `/login/`, `/logout/`, `/resend-verification/` per epic 2b §4 (issue #56).
- `LoginForm` rejects unverified users with a "check your inbox" path that surfaces a Resend button via `form.unverified_email`; correct-password-but-inactive is the only path that reveals account state, matching whitepaper §3.
- `login_redirect_for()` learns the OPERATOR-with-single-active-`LocationMembership` branch -> `/o/<slug>/l/<lslug>/pos/`.
- Login honors a safe `?next=` override (`url_has_allowed_host_and_scheme`) before falling through to the rule. Logout is POST-only and idempotent (no `@login_required`).
- Resend lives in a new service (`core/services/resend.py`) so the view stays free of raw `.objects` (tenant-lint).

## Deviations from whitepaper (called out in plan)
1. Honor `?next=` when safe.
2. `unverified_email` flag on the form (not HTML in the error string) so the resend button is rendered cleanly by the template.
3. Logout idempotent for anonymous POST.

## Test plan
- [x] `uv run pytest` -- 278 passed, 1 skipped.
- [x] `uv run pyright core/` -- 0 errors.
- [x] `uv run ruff check .` -- All checks passed.
- [x] `uv run python scripts/tenant_lint.py` -- clean.
- [x] Playwright end-to-end smoke through dev server: signup -> "check inbox" message on login -> resend -> verify -> auto-login -> logout -> re-login -> already-verified token -> safe `?next=` override.

🤖 Generated with [Claude Code](https://claude.com/claude-code)