### PR TITLE
feat(2b): password reset request + confirm flow

### DIFF
--- a/core/forms/auth.py
+++ b/core/forms/auth.py
@@ -1,6 +1,8 @@
+from collections.abc import Mapping
 from typing import Any
 
 from django import forms
+from django.contrib.auth.password_validation import validate_password
 from django.core.exceptions import ValidationError
 from django.utils.translation import gettext_lazy as _
 
@@ -49,3 +51,45 @@ class LoginForm(forms.Form):
 
     def get_user(self) -> User | None:
         return self.user_cache
+
+
+class PasswordResetRequestForm(forms.Form):
+    email = forms.EmailField(
+        label=_("Email"),
+        max_length=254,
+    )
+
+    def clean_email(self) -> str:
+        return (self.cleaned_data.get("email") or "").lower().strip()
+
+
+class PasswordResetConfirmForm(forms.Form):
+    new_password = forms.CharField(
+        label=_("New password"),
+        widget=forms.PasswordInput(render_value=False),
+        strip=False,
+    )
+    confirm_password = forms.CharField(
+        label=_("Confirm password"),
+        widget=forms.PasswordInput(render_value=False),
+        strip=False,
+    )
+
+    def __init__(
+        self, data: Mapping[str, Any] | None = None, *, user: User
+    ) -> None:
+        self.user = user
+        super().__init__(data)
+
+    def clean(self) -> dict[str, Any]:
+        cleaned: dict[str, Any] = super().clean() or {}
+        p1 = cleaned.get("new_password")
+        p2 = cleaned.get("confirm_password")
+        if p1 and p2 and p1 != p2:
+            self.add_error("confirm_password", _("Passwords do not match."))
+        if p1 and not self.has_error("new_password"):
+            try:
+                validate_password(p1, user=self.user)
+            except ValidationError as e:
+                self.add_error("new_password", e)
+        return cleaned

--- a/core/services/password_reset.py
+++ b/core/services/password_reset.py
@@ -1,0 +1,61 @@
+import logging
+
+from django.conf import settings
+from django.db import transaction
+from django.urls import reverse
+
+from core.models import OrganizationMembership, Role, User
+from core.services.mail import send_templated
+from core.services.tokens import RESET_SALT, make_token
+
+logger = logging.getLogger(__name__)
+
+
+def _send_reset_email(
+    *, user: User, language: str | None, reset_url: str
+) -> None:
+    # Best-effort. Swallowing keeps the request view non-enumerating: an
+    # SMTP / template failure on a real account must not turn the
+    # active-user branch into a 500 while missing/inactive return 200.
+    try:
+        send_templated(
+            "email/password_reset",
+            to=user,
+            language=language,
+            context={"reset_url": reset_url},
+        )
+    except Exception:
+        logger.exception("password reset email failed for user_id=%s", user.pk)
+
+
+def request_password_reset_email(email: str) -> None:
+    # Idempotent: looks up an active user by case-insensitive email and
+    # enqueues a reset email on commit. No-op for missing, inactive, or
+    # empty inputs so the caller can always render the same "sent"
+    # response without enumerating accounts (whitepaper epic 2b §4).
+    if not email:
+        return
+    user = User.objects.filter(email__iexact=email, is_active=True).first()
+    if user is None:
+        return
+    mem = (
+        OrganizationMembership.objects.filter(
+            user=user, role=Role.ADMIN, is_active=True
+        )
+        .select_related("organization")
+        .order_by("created_at")
+        .first()
+    )
+    language = mem.organization.default_language if mem else None
+    token = make_token(user, salt=RESET_SALT)
+    reset_url = (
+        f"{settings.SITE_URL}"
+        f"{reverse('core:password_reset_confirm', args=[token])}"
+    )
+    transaction.on_commit(
+        lambda: _send_reset_email(
+            user=user,
+            language=language,
+            reset_url=reset_url,
+        )
+    )

--- a/core/services/password_reset.py
+++ b/core/services/password_reset.py
@@ -1,14 +1,45 @@
+import hashlib
 import logging
 
 from django.conf import settings
+from django.core import signing
 from django.db import transaction
 from django.urls import reverse
 
 from core.models import OrganizationMembership, Role, User
 from core.services.mail import send_templated
-from core.services.tokens import RESET_SALT, make_token
+from core.services.tokens import RESET_MAX_AGE, RESET_SALT
 
 logger = logging.getLogger(__name__)
+
+
+def _password_fingerprint(user: User) -> str:
+    # Short SHA-256 prefix of the password hash. Embedded in the signed
+    # token so a successful reset invalidates the prior link: once
+    # set_password() runs, the stored hash changes and the token's
+    # fingerprint no longer matches. Keeps replay-after-success out of
+    # the 1h window without persisting per-token state.
+    return hashlib.sha256(user.password.encode()).hexdigest()[:16]
+
+
+def make_password_reset_token(user: User) -> str:
+    return signing.dumps(
+        {"user_id": user.pk, "pwf": _password_fingerprint(user)},
+        salt=RESET_SALT,
+    )
+
+
+def verify_password_reset_token(token: str) -> User:
+    # Raises signing.BadSignature (incl. SignatureExpired) on bad/expired
+    # tokens, on inactive users, and on fingerprint mismatch (the password
+    # has been rotated since the token was issued).
+    payload = signing.loads(token, salt=RESET_SALT, max_age=RESET_MAX_AGE)
+    user = User.objects.filter(
+        pk=payload.get("user_id"), is_active=True
+    ).first()
+    if user is None or _password_fingerprint(user) != payload.get("pwf"):
+        raise signing.BadSignature("password reset token no longer valid")
+    return user
 
 
 def _send_reset_email(
@@ -47,7 +78,7 @@ def request_password_reset_email(email: str) -> None:
         .first()
     )
     language = mem.organization.default_language if mem else None
-    token = make_token(user, salt=RESET_SALT)
+    token = make_password_reset_token(user)
     reset_url = (
         f"{settings.SITE_URL}"
         f"{reverse('core:password_reset_confirm', args=[token])}"

--- a/core/urls.py
+++ b/core/urls.py
@@ -7,6 +7,8 @@ from .views.auth import (
     login,
     logout,
     org_picker,
+    password_reset_confirm,
+    password_reset_request,
     resend_verification,
     signup,
     signup_done,
@@ -27,6 +29,16 @@ urlpatterns: list[URLPattern] = [
         route="resend-verification/",
         view=resend_verification,
         name="resend_verification",
+    ),
+    path(
+        route="password/reset/",
+        view=password_reset_request,
+        name="password_reset_request",
+    ),
+    path(
+        route="password/reset/<str:token>/",
+        view=password_reset_confirm,
+        name="password_reset_confirm",
     ),
     path(route="orgs/", view=org_picker, name="org_picker"),
 ]

--- a/core/views/auth.py
+++ b/core/views/auth.py
@@ -23,10 +23,12 @@ from core.models import OrganizationMembership, User
 from core.services.activation import activate_from_token
 from core.services.exceptions import AlreadyActiveError, NoAdminMembershipError
 from core.services.login_redirect import login_redirect_for
-from core.services.password_reset import request_password_reset_email
+from core.services.password_reset import (
+    request_password_reset_email,
+    verify_password_reset_token,
+)
 from core.services.resend import resend_verification_email
 from core.services.signup import create_organization_with_admin
-from core.services.tokens import RESET_MAX_AGE, RESET_SALT, verify_token
 
 
 def signup(request: HttpRequest) -> HttpResponse:
@@ -137,21 +139,13 @@ def password_reset_request(request: HttpRequest) -> HttpResponse:
 
 
 def password_reset_confirm(request: HttpRequest, token: str) -> HttpResponse:
+    # `verify_password_reset_token` folds together: signature/expiry check,
+    # active-user lookup, and password-fingerprint binding (a successful
+    # reset rotates the hash, which invalidates every prior token even
+    # within the 1h window).
     try:
-        payload = verify_token(token, salt=RESET_SALT, max_age=RESET_MAX_AGE)
+        user = verify_password_reset_token(token)
     except signing.BadSignature:
-        # SignatureExpired is a BadSignature subclass; one catch covers both.
-        return render(request, "auth/password_reset_failed.html")
-    # Cross-tenant by design: the signed token carries the user PK and the
-    # confirm page runs before any tenant context is selected, so there's
-    # no `for_request` / `for_organization` to scope to.
-    user = User.objects.filter(  # noqa: tenant-lint
-        pk=payload["user_id"], is_active=True
-    ).first()
-    if user is None:
-        # Account deactivated between request and confirm; mirrors the
-        # LoginForm rejection so an inactive user can't end up in a
-        # half-authenticated state via auth_login().
         return render(request, "auth/password_reset_failed.html")
     if request.method == "POST":
         form = PasswordResetConfirmForm(request.POST, user=user)

--- a/core/views/auth.py
+++ b/core/views/auth.py
@@ -142,7 +142,12 @@ def password_reset_confirm(request: HttpRequest, token: str) -> HttpResponse:
     except signing.BadSignature:
         # SignatureExpired is a BadSignature subclass; one catch covers both.
         return render(request, "auth/password_reset_failed.html")
-    user = User.objects.filter(pk=payload["user_id"], is_active=True).first()
+    # Cross-tenant by design: the signed token carries the user PK and the
+    # confirm page runs before any tenant context is selected, so there's
+    # no `for_request` / `for_organization` to scope to.
+    user = User.objects.filter(  # noqa: tenant-lint
+        pk=payload["user_id"], is_active=True
+    ).first()
     if user is None:
         # Account deactivated between request and confirm; mirrors the
         # LoginForm rejection so an inactive user can't end up in a

--- a/core/views/auth.py
+++ b/core/views/auth.py
@@ -13,14 +13,20 @@ from django.utils.translation import get_language
 from django.utils.translation import gettext_lazy as _
 from django.views.decorators.http import require_POST
 
-from core.forms.auth import LoginForm
+from core.forms.auth import (
+    LoginForm,
+    PasswordResetConfirmForm,
+    PasswordResetRequestForm,
+)
 from core.forms.signup import SignupForm
 from core.models import OrganizationMembership, User
 from core.services.activation import activate_from_token
 from core.services.exceptions import AlreadyActiveError, NoAdminMembershipError
 from core.services.login_redirect import login_redirect_for
+from core.services.password_reset import request_password_reset_email
 from core.services.resend import resend_verification_email
 from core.services.signup import create_organization_with_admin
+from core.services.tokens import RESET_MAX_AGE, RESET_SALT, verify_token
 
 
 def signup(request: HttpRequest) -> HttpResponse:
@@ -115,6 +121,47 @@ def resend_verification(request: HttpRequest) -> HttpResponse:
     email = (request.POST.get("email") or "").strip().lower()
     resend_verification_email(email)
     return render(request, "auth/verify_resent.html")
+
+
+def password_reset_request(request: HttpRequest) -> HttpResponse:
+    # Always renders the same "sent" template after POST so the response
+    # can't be used to enumerate accounts (whitepaper epic 2b §4).
+    if request.method == "POST":
+        form = PasswordResetRequestForm(request.POST)
+        if form.is_valid():
+            request_password_reset_email(form.cleaned_data["email"])
+            return render(request, "auth/password_reset_sent.html")
+    else:
+        form = PasswordResetRequestForm()
+    return render(request, "auth/password_reset_request.html", {"form": form})
+
+
+def password_reset_confirm(request: HttpRequest, token: str) -> HttpResponse:
+    try:
+        payload = verify_token(token, salt=RESET_SALT, max_age=RESET_MAX_AGE)
+    except signing.BadSignature:
+        # SignatureExpired is a BadSignature subclass; one catch covers both.
+        return render(request, "auth/password_reset_failed.html")
+    user = User.objects.filter(pk=payload["user_id"], is_active=True).first()
+    if user is None:
+        # Account deactivated between request and confirm; mirrors the
+        # LoginForm rejection so an inactive user can't end up in a
+        # half-authenticated state via auth_login().
+        return render(request, "auth/password_reset_failed.html")
+    if request.method == "POST":
+        form = PasswordResetConfirmForm(request.POST, user=user)
+        if form.is_valid():
+            user.set_password(form.cleaned_data["new_password"])
+            user.save(update_fields=["password"])
+            auth_login(request, user)
+            return redirect(login_redirect_for(user))
+    else:
+        form = PasswordResetConfirmForm(user=user)
+    return render(
+        request,
+        "auth/password_reset_confirm.html",
+        {"form": form, "token": token},
+    )
 
 
 @login_required

--- a/templates/auth/login.html
+++ b/templates/auth/login.html
@@ -23,5 +23,6 @@
     </form>
   {% endif %}
 
+  <p><a href="{% url 'core:password_reset_request' %}">{% trans "Forgot password?" %}</a></p>
   <p><a href="{% url 'core:signup' %}">{% trans "Create an account" %}</a></p>
 {% endblock %}

--- a/templates/auth/password_reset_confirm.html
+++ b/templates/auth/password_reset_confirm.html
@@ -1,0 +1,16 @@
+{% extends "base_public.html" %}
+{% load i18n forms %}
+
+{% block title %}{% trans "Choose a new password" %}{% endblock %}
+
+{% block main %}
+  <h1>{% trans "Choose a new password" %}</h1>
+  <form method="post" novalidate>
+    {% csrf_token %}
+    {% include "forms/_errors.html" %}
+    {% field form.new_password %}
+    {% field form.confirm_password %}
+    {% trans "Set new password" as submit_label %}
+    {% submit submit_label %}
+  </form>
+{% endblock %}

--- a/templates/auth/password_reset_failed.html
+++ b/templates/auth/password_reset_failed.html
@@ -1,0 +1,10 @@
+{% extends "base_public.html" %}
+{% load i18n %}
+
+{% block title %}{% trans "Reset link invalid" %}{% endblock %}
+
+{% block main %}
+  <h1>{% trans "This link is invalid or has expired" %}</h1>
+  <p>{% trans "Reset links expire after 1 hour. Request a new one to continue." %}</p>
+  <p><a href="{% url 'core:password_reset_request' %}">{% trans "Request a new link" %}</a></p>
+{% endblock %}

--- a/templates/auth/password_reset_request.html
+++ b/templates/auth/password_reset_request.html
@@ -1,0 +1,18 @@
+{% extends "base_public.html" %}
+{% load i18n forms %}
+
+{% block title %}{% trans "Reset password" %}{% endblock %}
+
+{% block main %}
+  <h1>{% trans "Reset password" %}</h1>
+  <p>{% trans "Enter the email for your account and we'll send a link to set a new password." %}</p>
+  <form method="post" novalidate>
+    {% csrf_token %}
+    {% include "forms/_errors.html" %}
+    {% field form.email %}
+    {% trans "Send reset link" as submit_label %}
+    {% submit submit_label %}
+  </form>
+
+  <p><a href="{% url 'core:login' %}">{% trans "Back to sign in" %}</a></p>
+{% endblock %}

--- a/templates/auth/password_reset_sent.html
+++ b/templates/auth/password_reset_sent.html
@@ -1,0 +1,10 @@
+{% extends "base_public.html" %}
+{% load i18n %}
+
+{% block title %}{% trans "Check your inbox" %}{% endblock %}
+
+{% block main %}
+  <h1>{% trans "Check your inbox" %}</h1>
+  <p>{% trans "If an account exists for that email, we've sent a link to reset your password. The link expires in 1 hour." %}</p>
+  <p><a href="{% url 'core:login' %}">{% trans "Back to sign in" %}</a></p>
+{% endblock %}

--- a/tests/test_auth_password_reset.py
+++ b/tests/test_auth_password_reset.py
@@ -9,7 +9,7 @@ from django.test import Client
 from django.urls import reverse
 
 from core.models import Role
-from core.services.tokens import RESET_SALT, make_token
+from core.services.password_reset import make_password_reset_token
 from tests.factories import (
     OrganizationFactory,
     OrganizationMembershipFactory,
@@ -124,7 +124,7 @@ def test_request_email_normalised_case_insensitive(
 def test_confirm_get_with_valid_token_renders_form() -> None:
     user = UserFactory(is_active=True)
     OrganizationMembershipFactory(user=user, role=Role.ADMIN)
-    token = make_token(user, salt=RESET_SALT)
+    token = make_password_reset_token(user)
 
     response = Client().get(
         reverse("core:password_reset_confirm", args=[token])
@@ -141,7 +141,7 @@ def test_confirm_valid_post_updates_password_and_logs_in() -> None:
     user = UserFactory(is_active=True)
     org = OrganizationFactory(slug="frituur-janssens")
     OrganizationMembershipFactory(user=user, organization=org, role=Role.ADMIN)
-    token = make_token(user, salt=RESET_SALT)
+    token = make_password_reset_token(user)
     client = Client()
 
     response = client.post(
@@ -165,7 +165,7 @@ def test_confirm_valid_post_updates_password_and_logs_in() -> None:
 def test_confirm_mismatched_passwords_keep_old_password() -> None:
     user = UserFactory(is_active=True)
     OrganizationMembershipFactory(user=user, role=Role.ADMIN)
-    token = make_token(user, salt=RESET_SALT)
+    token = make_password_reset_token(user)
 
     response = Client().post(
         reverse("core:password_reset_confirm", args=[token]),
@@ -190,7 +190,7 @@ def test_confirm_mismatched_passwords_keep_old_password() -> None:
 def test_confirm_weak_password_keeps_old_password() -> None:
     user = UserFactory(is_active=True)
     OrganizationMembershipFactory(user=user, role=Role.ADMIN)
-    token = make_token(user, salt=RESET_SALT)
+    token = make_password_reset_token(user)
 
     response = Client().post(
         reverse("core:password_reset_confirm", args=[token]),
@@ -225,10 +225,10 @@ def test_confirm_tampered_token_renders_failed() -> None:
 def test_confirm_expired_token_renders_failed() -> None:
     user = UserFactory(is_active=True)
     OrganizationMembershipFactory(user=user, role=Role.ADMIN)
-    token = make_token(user, salt=RESET_SALT)
+    token = make_password_reset_token(user)
 
     with patch(
-        "core.views.auth.verify_token",
+        "core.views.auth.verify_password_reset_token",
         side_effect=signing.SignatureExpired("expired"),
     ):
         response = Client().get(
@@ -246,7 +246,7 @@ def test_confirm_inactive_user_renders_failed() -> None:
     # Token issued while user was active; user later deactivated.
     user = UserFactory(is_active=True)
     OrganizationMembershipFactory(user=user, role=Role.ADMIN)
-    token = make_token(user, salt=RESET_SALT)
+    token = make_password_reset_token(user)
     user.is_active = False
     user.save(update_fields=["is_active"])
 
@@ -266,6 +266,43 @@ def test_confirm_inactive_user_renders_failed() -> None:
     assert user.check_password("password")
     auth_user = get_user(Client())
     assert not auth_user.is_authenticated
+
+
+@pytest.mark.django_db
+def test_confirm_token_invalidated_after_successful_reset() -> None:
+    # The token is bound to the user's password hash via a fingerprint in
+    # the signed payload. Once the password is rotated the same link must
+    # not be reusable to overwrite the password again, even within the
+    # 1h signing window. (Codex review #69, P2.)
+    user = UserFactory(is_active=True)
+    OrganizationMembershipFactory(user=user, role=Role.ADMIN)
+    token = make_password_reset_token(user)
+
+    first = Client().post(
+        reverse("core:password_reset_confirm", args=[token]),
+        {
+            "new_password": "n3w-l0ng-p4ssword!",
+            "confirm_password": "n3w-l0ng-p4ssword!",
+        },
+    )
+    assert first.status_code == 302
+
+    # Replay the same token: the password hash has changed so the
+    # fingerprint no longer matches.
+    replay = Client().post(
+        reverse("core:password_reset_confirm", args=[token]),
+        {
+            "new_password": "h1jacked-p4ssword!",
+            "confirm_password": "h1jacked-p4ssword!",
+        },
+    )
+    assert replay.status_code == 200
+    assert "auth/password_reset_failed.html" in [
+        t.name for t in replay.templates
+    ]
+    user.refresh_from_db()
+    assert user.check_password("n3w-l0ng-p4ssword!")
+    assert not user.check_password("h1jacked-p4ssword!")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_auth_password_reset.py
+++ b/tests/test_auth_password_reset.py
@@ -1,0 +1,280 @@
+import re
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+from django.contrib.auth import get_user
+from django.core import signing
+from django.test import Client
+from django.urls import reverse
+
+from core.models import Role
+from core.services.tokens import RESET_SALT, make_token
+from tests.factories import (
+    OrganizationFactory,
+    OrganizationMembershipFactory,
+    UserFactory,
+)
+
+_Capture = Any
+
+# ---------------------------------------------------------------------------
+# Request flow (issue #58)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_request_get_renders_form() -> None:
+    response = Client().get(reverse("core:password_reset_request"))
+    assert response.status_code == 200
+    assert "auth/password_reset_request.html" in [
+        t.name for t in response.templates
+    ]
+
+
+@pytest.mark.django_db
+def test_request_active_user_sends_mail(
+    mailoutbox: list,
+    django_capture_on_commit_callbacks: _Capture,
+) -> None:
+    user = UserFactory(email="alice@example.be", is_active=True)
+    OrganizationMembershipFactory(user=user, role=Role.ADMIN)
+
+    with django_capture_on_commit_callbacks(execute=True):
+        response = Client().post(
+            reverse("core:password_reset_request"),
+            {"email": "alice@example.be"},
+        )
+
+    assert response.status_code == 200
+    assert "auth/password_reset_sent.html" in [
+        t.name for t in response.templates
+    ]
+    assert len(mailoutbox) == 1
+    msg = mailoutbox[0]
+    assert msg.to == ["alice@example.be"]
+    # Body contains a usable reset_url whose path resolves to the confirm view.
+    match = re.search(r"https?://\S+/password/reset/(\S+)/", msg.body)
+    assert match is not None
+    token = match.group(1)
+    # Resolve the URL: this proves the route name + path shape are wired.
+    expected_path = reverse("core:password_reset_confirm", args=[token])
+    assert expected_path in msg.body
+
+
+@pytest.mark.django_db
+def test_request_unknown_email_renders_sent_no_mail(
+    mailoutbox: list,
+) -> None:
+    response = Client().post(
+        reverse("core:password_reset_request"),
+        {"email": "nobody@example.be"},
+    )
+
+    assert response.status_code == 200
+    assert "auth/password_reset_sent.html" in [
+        t.name for t in response.templates
+    ]
+    assert mailoutbox == []
+
+
+@pytest.mark.django_db
+def test_request_inactive_user_renders_sent_no_mail(
+    mailoutbox: list,
+) -> None:
+    user = UserFactory(email="bob@example.be", is_active=False)
+    OrganizationMembershipFactory(user=user, role=Role.ADMIN)
+
+    response = Client().post(
+        reverse("core:password_reset_request"),
+        {"email": "bob@example.be"},
+    )
+
+    assert response.status_code == 200
+    assert "auth/password_reset_sent.html" in [
+        t.name for t in response.templates
+    ]
+    assert mailoutbox == []
+
+
+@pytest.mark.django_db
+def test_request_email_normalised_case_insensitive(
+    mailoutbox: list,
+    django_capture_on_commit_callbacks: _Capture,
+) -> None:
+    user = UserFactory(email="alice@example.be", is_active=True)
+    OrganizationMembershipFactory(user=user, role=Role.ADMIN)
+
+    with django_capture_on_commit_callbacks(execute=True):
+        response = Client().post(
+            reverse("core:password_reset_request"),
+            {"email": "  ALICE@example.be  "},
+        )
+
+    assert response.status_code == 200
+    assert len(mailoutbox) == 1
+
+
+# ---------------------------------------------------------------------------
+# Confirm flow (issue #59)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_confirm_get_with_valid_token_renders_form() -> None:
+    user = UserFactory(is_active=True)
+    OrganizationMembershipFactory(user=user, role=Role.ADMIN)
+    token = make_token(user, salt=RESET_SALT)
+
+    response = Client().get(
+        reverse("core:password_reset_confirm", args=[token])
+    )
+
+    assert response.status_code == 200
+    assert "auth/password_reset_confirm.html" in [
+        t.name for t in response.templates
+    ]
+
+
+@pytest.mark.django_db
+def test_confirm_valid_post_updates_password_and_logs_in() -> None:
+    user = UserFactory(is_active=True)
+    org = OrganizationFactory(slug="frituur-janssens")
+    OrganizationMembershipFactory(user=user, organization=org, role=Role.ADMIN)
+    token = make_token(user, salt=RESET_SALT)
+    client = Client()
+
+    response = client.post(
+        reverse("core:password_reset_confirm", args=[token]),
+        {
+            "new_password": "n3w-l0ng-p4ssword!",
+            "confirm_password": "n3w-l0ng-p4ssword!",
+        },
+    )
+
+    assert response.status_code == 302
+    assert response["Location"] == "/o/frituur-janssens/"
+    user.refresh_from_db()
+    assert user.check_password("n3w-l0ng-p4ssword!")
+    auth_user = get_user(client)
+    assert auth_user.is_authenticated
+    assert auth_user.pk == user.pk
+
+
+@pytest.mark.django_db
+def test_confirm_mismatched_passwords_keep_old_password() -> None:
+    user = UserFactory(is_active=True)
+    OrganizationMembershipFactory(user=user, role=Role.ADMIN)
+    token = make_token(user, salt=RESET_SALT)
+
+    response = Client().post(
+        reverse("core:password_reset_confirm", args=[token]),
+        {
+            "new_password": "n3w-l0ng-p4ssword!",
+            "confirm_password": "different-l0ng-p4ssword!",
+        },
+    )
+
+    assert response.status_code == 200
+    assert "auth/password_reset_confirm.html" in [
+        t.name for t in response.templates
+    ]
+    form = response.context["form"]
+    assert "confirm_password" in form.errors
+    user.refresh_from_db()
+    # Default factory password "password" is unchanged.
+    assert user.check_password("password")
+
+
+@pytest.mark.django_db
+def test_confirm_weak_password_keeps_old_password() -> None:
+    user = UserFactory(is_active=True)
+    OrganizationMembershipFactory(user=user, role=Role.ADMIN)
+    token = make_token(user, salt=RESET_SALT)
+
+    response = Client().post(
+        reverse("core:password_reset_confirm", args=[token]),
+        {"new_password": "12345", "confirm_password": "12345"},
+    )
+
+    assert response.status_code == 200
+    form = response.context["form"]
+    assert "new_password" in form.errors
+    user.refresh_from_db()
+    assert user.check_password("password")
+
+
+@pytest.mark.django_db
+def test_confirm_tampered_token_renders_failed() -> None:
+    user = UserFactory(is_active=True)
+    OrganizationMembershipFactory(user=user, role=Role.ADMIN)
+
+    response = Client().get(
+        reverse("core:password_reset_confirm", args=["not-a-token"])
+    )
+
+    assert response.status_code == 200
+    assert "auth/password_reset_failed.html" in [
+        t.name for t in response.templates
+    ]
+    user.refresh_from_db()
+    assert user.check_password("password")
+
+
+@pytest.mark.django_db
+def test_confirm_expired_token_renders_failed() -> None:
+    user = UserFactory(is_active=True)
+    OrganizationMembershipFactory(user=user, role=Role.ADMIN)
+    token = make_token(user, salt=RESET_SALT)
+
+    with patch(
+        "core.views.auth.verify_token",
+        side_effect=signing.SignatureExpired("expired"),
+    ):
+        response = Client().get(
+            reverse("core:password_reset_confirm", args=[token])
+        )
+
+    assert response.status_code == 200
+    assert "auth/password_reset_failed.html" in [
+        t.name for t in response.templates
+    ]
+
+
+@pytest.mark.django_db
+def test_confirm_inactive_user_renders_failed() -> None:
+    # Token issued while user was active; user later deactivated.
+    user = UserFactory(is_active=True)
+    OrganizationMembershipFactory(user=user, role=Role.ADMIN)
+    token = make_token(user, salt=RESET_SALT)
+    user.is_active = False
+    user.save(update_fields=["is_active"])
+
+    response = Client().post(
+        reverse("core:password_reset_confirm", args=[token]),
+        {
+            "new_password": "n3w-l0ng-p4ssword!",
+            "confirm_password": "n3w-l0ng-p4ssword!",
+        },
+    )
+
+    assert response.status_code == 200
+    assert "auth/password_reset_failed.html" in [
+        t.name for t in response.templates
+    ]
+    user.refresh_from_db()
+    assert user.check_password("password")
+    auth_user = get_user(Client())
+    assert not auth_user.is_authenticated
+
+
+# ---------------------------------------------------------------------------
+# Login page entry-point smoke test
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_login_page_links_to_password_reset() -> None:
+    response = Client().get(reverse("core:login"))
+    assert response.status_code == 200
+    assert reverse("core:password_reset_request") in response.content.decode()


### PR DESCRIPTION
## Summary
- New `/password/reset/` request view: signed 1h token via email, no-enumeration response on missing/inactive accounts (mirrors `core/services/resend.py`).
- New `/password/reset/<token>/` confirm view: validates token + Django password validators, rotates the hash, auto-logs in via `login_redirect_for`. Rejects users that became inactive between request and confirm.
- "Forgot password?" link added to `templates/auth/login.html` so the flow is reachable.

Closes #58, closes #59.

## Approved deviations from the whitepaper / issues
- Skipped `password/reset/sent/` and `password/reset/done/` URLs: the sent template renders directly from the POST (mirrors `resend_verification`), and confirm always redirects via `login_redirect_for` which always returns a target.
- Reject deactivated-after-issue users at the confirm step (renders `password_reset_failed.html`) instead of letting `auth_login` produce a half-authenticated state.

## Reused (no rebuild)
- `core/services/tokens.py` (`make_token`, `verify_token`, `RESET_SALT`, `RESET_MAX_AGE`)
- `core/services/mail.py:send_templated`
- `templates/email/password_reset.{txt,html}` and subject template
- `core/services/login_redirect.py:login_redirect_for`

## Test plan
- [x] `uv run pytest tests/test_auth_password_reset.py -v` (13 cases, all green)
- [x] `uv run pytest` (298 passed, 1 skipped)
- [x] `uv run ruff check` clean
- [x] `uv run pyright` clean on changed files
- [x] Manual Playwright run: login link -> request form -> sent page -> email in console -> reset URL -> mismatched / weak / valid passwords -> 302 to `/o/<slug>/` authenticated, old password rejected and new password accepted in DB. Tampered token renders failed page. Unknown email returns identical 1162-byte sent page with no email written (no enumeration).

🤖 Generated with [Claude Code](https://claude.com/claude-code)