### PR TITLE
feat(2c): invitation email templates + revoked notice

### DIFF
--- a/.claude/skills/issue/SKILL.md
+++ b/.claude/skills/issue/SKILL.md
@@ -1,0 +1,19 @@
+---
+description: Plans the implementation for a GitHub issue by finding and reviewing relevant documentation.
+argument-hint: [issue-number-or-url]
+arguments: ISSUE
+disable-model-invocation: true
+---
+
+Please analyze and plan the implementation for the following GitHub issue: $ISSUE
+
+Context Gathering:
+
+1. Read the provided issue description carefully.
+2. Based on the issue's context, search for and review the most relevant whitepaper(s) or documentation located in the `docs/` directory.
+
+Instructions:
+
+1. Propose a high-level, step-by-step implementation plan based on the issue and the documentation you found.
+2. Suggest improvements: If you see a better approach that deviates slightly from the established documentation, please suggest it. Explicitly highlight any deviations and explain your rationale.
+3. Before writing any code, please list out any clarifying questions you have or missing context you need to proceed effectively.

--- a/.claude/skills/review_pr/SKILL.md
+++ b/.claude/skills/review_pr/SKILL.md
@@ -1,0 +1,25 @@
+---
+description: Performs a comprehensive code review of a GitHub Pull Request and posts comments via the GitHub CLI.
+argument-hint: [PR number or url]
+arguments: pr
+disable-model-invocation: true
+---
+
+Please perform a deep and comprehensive review of the following pull request: $pr
+
+Context Gathering:
+
+1. Use the GitHub CLI (`gh pr view $pr` and `gh pr diff $pr`) to read the PR description, understand its goal, and analyze the changed files.
+
+Review Criteria:
+Evaluate the code specifically for:
+
+- Logic errors, unhandled edge cases, and potential bugs.
+- Performance bottlenecks or security vulnerabilities.
+- Architectural alignment with the existing codebase.
+  (Skip minor styling nitpicks unless they violate severe readability standards).
+
+Action:
+
+1. Local Summary: First, summarize your core findings and feedback to me here in the chat.
+2. PR Comments: Once you have formulated your feedback, use the GitHub CLI to post constructive comments directly to the PR. Use inline comments for specific line issues, and a general review comment for overall architectural feedback.

--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,7 @@ coverage.xml
 .mypy_cache/
 .pyright/
 .playwright-mcp/
+.gemini/
 
 # IDE / OS
 .idea/

--- a/core/services/invitation.py
+++ b/core/services/invitation.py
@@ -42,15 +42,19 @@ def _send_invitation_email(invitation: Invitation) -> None:
             .only("email", "preferred_language")
             .first()
         )
-        language = invitation.organization.default_language
+        org_lang = invitation.organization.default_language
         if existing is None:
             # Unsaved User just to satisfy send_templated's `to: User`
             # contract (it reads `email` and `preferred_language` only).
             addressee = User(
-                email=invitation.email, preferred_language=language
+                email=invitation.email, preferred_language=org_lang
             )
+            language = org_lang
         else:
+            # Epic 2c §6: existing user's preferred_language wins; fall back
+            # to the org default when blank.
             addressee = existing
+            language = existing.preferred_language or org_lang
         token = make_invite_token(invitation)
         accept_url = f"{settings.SITE_URL}/invite/{token}/"
         inviter = invitation.created_by

--- a/core/services/invitation.py
+++ b/core/services/invitation.py
@@ -53,14 +53,22 @@ def _send_invitation_email(invitation: Invitation) -> None:
             addressee = existing
         token = make_invite_token(invitation)
         accept_url = f"{settings.SITE_URL}/invite/{token}/"
+        inviter = invitation.created_by
+        inviter_name = (
+            f"{inviter.first_name} {inviter.last_name}".strip() or inviter.email
+        )
         send_templated(
             "email/invitation",
             to=addressee,
             language=language,
             context={
-                "accept_url": accept_url,
-                "org_name": invitation.organization.name,
+                "invitee_email": invitation.email,
+                "inviter_name": inviter_name,
+                "organization_name": invitation.organization.name,
                 "role": invitation.role,
+                "locations": list(invitation.locations.all()),
+                "accept_url": accept_url,
+                "expires_at": invitation.expires_at,
             },
         )
     except Exception:

--- a/locale/de_DE/LC_MESSAGES/django.po
+++ b/locale/de_DE/LC_MESSAGES/django.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: rapido\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-05-01 23:26+0000\n"
+"POT-Creation-Date: 2026-05-03 00:28+0000\n"
 "PO-Revision-Date: 2026-05-01 11:19+0000\n"
 "Language-Team: German\n"
 "Language: de_DE\n"
@@ -49,10 +49,123 @@ msgstr "Persönliche Informationen"
 msgid "Permissions"
 msgstr "Berechtigungen"
 
-#: core/models/location.py:27 core/models/membership.py:29
-#: core/models/organization.py:76
+#: core/forms/auth.py:14 core/forms/auth.py:58 core/forms/signup.py:16
+#: core/views/design.py:37
+#, fuzzy
+#| msgid "email"
+msgid "Email"
+msgstr "E-Mail"
+
+#: core/forms/auth.py:18 core/forms/signup.py:20
+msgid "Password"
+msgstr ""
+
+#: core/forms/auth.py:40
+msgid "Invalid email or password."
+msgstr ""
+
+#: core/forms/auth.py:45
+msgid ""
+"Your email isn't verified yet. Check your inbox for the verification link."
+msgstr ""
+
+#: core/forms/auth.py:68
+msgid "New password"
+msgstr ""
+
+#: core/forms/auth.py:73
+msgid "Confirm password"
+msgstr ""
+
+#: core/forms/auth.py:89
+msgid "Passwords do not match."
+msgstr ""
+
+#: core/forms/signup.py:25
+#, fuzzy
+#| msgid "organization"
+msgid "Organisation name"
+msgstr "Organisation"
+
+#: core/forms/signup.py:29
+msgid "URL slug"
+msgstr ""
+
+#: core/forms/signup.py:34 core/models/organization.py:64
+msgid "VAT number"
+msgstr "USt-IdNr."
+
+#: core/forms/signup.py:37
+#, fuzzy
+#| msgid "country"
+msgid "Country"
+msgstr "Land"
+
+#: core/forms/signup.py:39
+#, fuzzy
+#| msgid "default language"
+msgid "Language"
+msgstr "Standardsprache"
+
+#: core/forms/signup.py:57
+msgid "This slug is already taken."
+msgstr ""
+
+#: core/forms/signup.py:62
+msgid "An account with this email already exists."
+msgstr ""
+
+#: core/models/invitation.py:32 core/models/location.py:27
+#: core/models/membership.py:29 core/models/organization.py:76
 msgid "organization"
 msgstr "Organisation"
+
+#: core/models/invitation.py:35 core/models/user.py:57
+msgid "email"
+msgstr "E-Mail"
+
+#: core/models/invitation.py:40 core/models/membership.py:34
+msgid "role"
+msgstr "Rolle"
+
+#: core/models/invitation.py:46 core/models/location.py:57
+msgid "locations"
+msgstr "Standorte"
+
+#: core/models/invitation.py:52 core/models/membership.py:45
+#: core/models/membership.py:91
+msgid "created by"
+msgstr "erstellt von"
+
+#: core/models/invitation.py:60
+#, fuzzy
+#| msgid "created by"
+msgid "revoked by"
+msgstr "erstellt von"
+
+#: core/models/invitation.py:63
+msgid "expires at"
+msgstr ""
+
+#: core/models/invitation.py:66
+msgid "accepted at"
+msgstr ""
+
+#: core/models/invitation.py:69
+msgid "revoked at"
+msgstr ""
+
+#: core/models/invitation.py:78
+#, fuzzy
+#| msgid "organization"
+msgid "invitation"
+msgstr "Organisation"
+
+#: core/models/invitation.py:79
+#, fuzzy
+#| msgid "organizations"
+msgid "invitations"
+msgstr "Organisationen"
 
 #: core/models/location.py:30 core/models/organization.py:34
 msgid "name"
@@ -92,10 +205,6 @@ msgstr "aktiv"
 msgid "location"
 msgstr "Standort"
 
-#: core/models/location.py:57
-msgid "locations"
-msgstr "Standorte"
-
 #: core/models/membership.py:14
 msgid "Admin"
 msgstr "Administrator"
@@ -108,14 +217,6 @@ msgstr "Operator"
 #: core/models/user.py:87
 msgid "user"
 msgstr "Benutzer"
-
-#: core/models/membership.py:34
-msgid "role"
-msgstr "Rolle"
-
-#: core/models/membership.py:45 core/models/membership.py:91
-msgid "created by"
-msgstr "erstellt von"
 
 #: core/models/membership.py:51
 msgid "organization membership"
@@ -157,10 +258,6 @@ msgstr "Standardwährung"
 msgid "default language"
 msgstr "Standardsprache"
 
-#: core/models/organization.py:64
-msgid "VAT number"
-msgstr "USt-IdNr."
-
 #: core/models/organization.py:67
 msgid "billing email"
 msgstr "Rechnungs-E-Mail"
@@ -180,10 +277,6 @@ msgstr "Superuser muss is_staff=True haben."
 #: core/models/user.py:48
 msgid "Superuser must have is_superuser=True."
 msgstr "Superuser muss is_superuser=True haben."
-
-#: core/models/user.py:57
-msgid "email"
-msgstr "E-Mail"
 
 #: core/models/user.py:60
 msgid "first name"
@@ -224,6 +317,10 @@ msgstr "Ungültiger Währungscode. Unterstützte Währungen: %(currencies)s."
 msgid "URL must contain only lowercase letters, digits, and hyphens."
 msgstr "URL darf nur Kleinbuchstaben, Ziffern und Bindestriche enthalten."
 
+#: core/views/auth.py:54
+msgid "This email or organisation slug is already in use."
+msgstr ""
+
 #: core/views/design.py:36
 msgid "Name"
 msgstr ""
@@ -231,12 +328,6 @@ msgstr ""
 #: core/views/design.py:36
 msgid "Your full name."
 msgstr ""
-
-#: core/views/design.py:37
-#, fuzzy
-#| msgid "email"
-msgid "Email"
-msgstr "E-Mail"
 
 #: core/views/design.py:39
 msgid "Role"
@@ -265,8 +356,166 @@ msgstr "Standardsprache"
 msgid "Profile"
 msgstr ""
 
-#: templates/_partials/user_menu.html:3
+#: templates/_partials/user_menu.html:3 templates/auth/org_picker.html:28
 msgid "Sign out"
+msgstr ""
+
+#: templates/auth/login.html:4 templates/auth/login.html:7
+#: templates/auth/login.html:14 templates/auth/verify_already.html:9
+#: templates/auth/verify_failed.html:9
+msgid "Sign in"
+msgstr ""
+
+#: templates/auth/login.html:22
+msgid "Resend verification email"
+msgstr ""
+
+#: templates/auth/login.html:26
+msgid "Forgot password?"
+msgstr ""
+
+#: templates/auth/login.html:27
+msgid "Create an account"
+msgstr ""
+
+#: templates/auth/org_picker.html:4 templates/auth/org_picker.html:8
+#, fuzzy
+#| msgid "organization"
+msgid "Choose an organisation"
+msgstr "Organisation"
+
+#: templates/auth/org_picker.html:24
+#, fuzzy
+#| msgid "organizations"
+msgid "No organisations"
+msgstr "Organisationen"
+
+#: templates/auth/org_picker.html:25
+msgid "Your account isn't linked to any active organisation."
+msgstr ""
+
+#: templates/auth/password_reset_confirm.html:4
+#: templates/auth/password_reset_confirm.html:7
+msgid "Choose a new password"
+msgstr ""
+
+#: templates/auth/password_reset_confirm.html:13
+msgid "Set new password"
+msgstr ""
+
+#: templates/auth/password_reset_failed.html:4
+msgid "Reset link invalid"
+msgstr ""
+
+#: templates/auth/password_reset_failed.html:7
+msgid "This link is invalid or has expired"
+msgstr ""
+
+#: templates/auth/password_reset_failed.html:8
+msgid "Reset links expire after 1 hour. Request a new one to continue."
+msgstr ""
+
+#: templates/auth/password_reset_failed.html:9
+msgid "Request a new link"
+msgstr ""
+
+#: templates/auth/password_reset_request.html:4
+#: templates/auth/password_reset_request.html:7
+#: templates/email/password_reset.html:7
+msgid "Reset password"
+msgstr ""
+
+#: templates/auth/password_reset_request.html:8
+msgid ""
+"Enter the email for your account and we'll send a link to set a new password."
+msgstr ""
+
+#: templates/auth/password_reset_request.html:13
+msgid "Send reset link"
+msgstr ""
+
+#: templates/auth/password_reset_request.html:17
+#: templates/auth/password_reset_sent.html:9
+msgid "Back to sign in"
+msgstr ""
+
+#: templates/auth/password_reset_sent.html:4
+#: templates/auth/password_reset_sent.html:7 templates/auth/signup_done.html:4
+#: templates/auth/signup_done.html:7 templates/auth/verify_resent.html:4
+#: templates/auth/verify_resent.html:7
+msgid "Check your inbox"
+msgstr ""
+
+#: templates/auth/password_reset_sent.html:8
+msgid ""
+"If an account exists for that email, we've sent a link to reset your "
+"password. The link expires in 1 hour."
+msgstr ""
+
+#: templates/auth/signup.html:4
+msgid "Create your account"
+msgstr ""
+
+#: templates/auth/signup.html:7
+#, fuzzy
+#| msgid "organization"
+msgid "Create your organisation"
+msgstr "Organisation"
+
+#: templates/auth/signup.html:31
+#, fuzzy
+#| msgid "URL must contain only lowercase letters, digits, and hyphens."
+msgid "Lowercase letters, numbers, and dashes."
+msgstr "URL darf nur Kleinbuchstaben, Ziffern und Bindestriche enthalten."
+
+#: templates/auth/signup.html:33
+msgid "Format: BE0123456789"
+msgstr ""
+
+#: templates/auth/signup.html:37
+msgid "Create account"
+msgstr ""
+
+#: templates/auth/signup_done.html:8
+msgid ""
+"We've sent a verification link to your email. Click it to activate your "
+"account."
+msgstr ""
+
+#: templates/auth/signup_done.html:9
+msgid "The link is valid for 7 days."
+msgstr ""
+
+#: templates/auth/verify_already.html:4 templates/auth/verify_already.html:7
+msgid "Already verified"
+msgstr ""
+
+#: templates/auth/verify_already.html:8
+msgid "Your email is already verified - this link has been used."
+msgstr ""
+
+#: templates/auth/verify_failed.html:4
+msgid "Verification link invalid"
+msgstr ""
+
+#: templates/auth/verify_failed.html:7
+msgid "Verification link invalid or expired"
+msgstr ""
+
+#: templates/auth/verify_failed.html:8
+msgid ""
+"This verification link can't be used. It may have expired (links are valid "
+"for 7 days), been tampered with, or already replaced by a newer one."
+msgstr ""
+
+#: templates/auth/verify_failed.html:9
+msgid "to request a new verification email."
+msgstr ""
+
+#: templates/auth/verify_resent.html:8
+msgid ""
+"If an unverified account exists for that email, we've sent a fresh "
+"verification link."
 msgstr ""
 
 #: templates/base_org.html:7 templates/base_picker.html:7
@@ -279,20 +528,75 @@ msgstr ""
 msgid "Sent by %(brand)s."
 msgstr ""
 
+#: templates/email/invitation.html:3 templates/email/invitation.txt:3
+#: templates/email/invitation_revoked.html:3
+#: templates/email/invitation_revoked.txt:3
 #: templates/email/password_reset.html:3 templates/email/password_reset.txt:3
 #: templates/email/verify.html:3 templates/email/verify.txt:3
 #, python-format
 msgid "Hi %(name)s,"
 msgstr ""
 
+#: templates/email/invitation.html:4 templates/email/invitation.txt:5
+#, python-format
+msgid "%(inviter)s invited you to join %(org)s on %(brand)s."
+msgstr ""
+
+#: templates/email/invitation.html:5 templates/email/invitation.txt:7
+msgid "You'll join as an administrator."
+msgstr ""
+
+#: templates/email/invitation.html:5 templates/email/invitation.txt:7
+msgid "You'll join as an operator."
+msgstr ""
+
+#: templates/email/invitation.html:7 templates/email/invitation.txt:9
+msgid "Your assigned locations:"
+msgstr ""
+
+#: templates/email/invitation.html:14
+msgid "Accept invitation"
+msgstr ""
+
+#: templates/email/invitation.html:17 templates/email/invitation.txt:16
+#: templates/email/verify.html:10 templates/email/verify.txt:9
+#, python-format
+msgid "This link expires in %(days)s day."
+msgid_plural "This link expires in %(days)s days."
+msgstr[0] ""
+msgstr[1] ""
+
+#: templates/email/invitation.html:20 templates/email/invitation.txt:18
+#, python-format
+msgid "Sent for %(org)s. "
+msgstr ""
+
+#: templates/email/invitation.txt:12
+msgid "Accept your invitation:"
+msgstr ""
+
+#: templates/email/invitation_revoked.html:4
+#: templates/email/invitation_revoked.txt:5
+#, python-format
+msgid ""
+"Your invitation to join %(org)s on %(brand)s has been withdrawn. No action "
+"is needed."
+msgstr ""
+
+#: templates/email/invitation_revoked_subject.txt:1
+#, python-format
+msgid "Your invitation to %(org)s was withdrawn"
+msgstr ""
+
+#: templates/email/invitation_subject.txt:1
+#, python-format
+msgid "You're invited to %(org)s on %(brand)s"
+msgstr ""
+
 #: templates/email/password_reset.html:4
 msgid ""
 "We received a request to reset your password. Use the button below to choose "
 "a new one:"
-msgstr ""
-
-#: templates/email/password_reset.html:7
-msgid "Reset password"
 msgstr ""
 
 #: templates/email/password_reset.html:10 templates/email/password_reset.txt:9
@@ -319,13 +623,6 @@ msgstr ""
 #: templates/email/verify.html:7
 msgid "Verify email"
 msgstr ""
-
-#: templates/email/verify.html:10 templates/email/verify.txt:9
-#, python-format
-msgid "This link expires in %(days)s day."
-msgid_plural "This link expires in %(days)s days."
-msgstr[0] ""
-msgstr[1] ""
 
 #: templates/email/verify.html:13 templates/email/verify.txt:11
 #, python-format

--- a/locale/fr_BE/LC_MESSAGES/django.po
+++ b/locale/fr_BE/LC_MESSAGES/django.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: rapido\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-05-01 23:26+0000\n"
+"POT-Creation-Date: 2026-05-03 00:28+0000\n"
 "PO-Revision-Date: 2026-05-01 11:19+0000\n"
 "Language-Team: French (Belgium)\n"
 "Language: fr_BE\n"
@@ -49,10 +49,123 @@ msgstr "Informations personnelles"
 msgid "Permissions"
 msgstr "Permissions"
 
-#: core/models/location.py:27 core/models/membership.py:29
-#: core/models/organization.py:76
+#: core/forms/auth.py:14 core/forms/auth.py:58 core/forms/signup.py:16
+#: core/views/design.py:37
+#, fuzzy
+#| msgid "email"
+msgid "Email"
+msgstr "e-mail"
+
+#: core/forms/auth.py:18 core/forms/signup.py:20
+msgid "Password"
+msgstr ""
+
+#: core/forms/auth.py:40
+msgid "Invalid email or password."
+msgstr ""
+
+#: core/forms/auth.py:45
+msgid ""
+"Your email isn't verified yet. Check your inbox for the verification link."
+msgstr ""
+
+#: core/forms/auth.py:68
+msgid "New password"
+msgstr ""
+
+#: core/forms/auth.py:73
+msgid "Confirm password"
+msgstr ""
+
+#: core/forms/auth.py:89
+msgid "Passwords do not match."
+msgstr ""
+
+#: core/forms/signup.py:25
+#, fuzzy
+#| msgid "organization"
+msgid "Organisation name"
+msgstr "organisation"
+
+#: core/forms/signup.py:29
+msgid "URL slug"
+msgstr ""
+
+#: core/forms/signup.py:34 core/models/organization.py:64
+msgid "VAT number"
+msgstr "numéro de TVA"
+
+#: core/forms/signup.py:37
+#, fuzzy
+#| msgid "country"
+msgid "Country"
+msgstr "pays"
+
+#: core/forms/signup.py:39
+#, fuzzy
+#| msgid "default language"
+msgid "Language"
+msgstr "langue par défaut"
+
+#: core/forms/signup.py:57
+msgid "This slug is already taken."
+msgstr ""
+
+#: core/forms/signup.py:62
+msgid "An account with this email already exists."
+msgstr ""
+
+#: core/models/invitation.py:32 core/models/location.py:27
+#: core/models/membership.py:29 core/models/organization.py:76
 msgid "organization"
 msgstr "organisation"
+
+#: core/models/invitation.py:35 core/models/user.py:57
+msgid "email"
+msgstr "e-mail"
+
+#: core/models/invitation.py:40 core/models/membership.py:34
+msgid "role"
+msgstr "rôle"
+
+#: core/models/invitation.py:46 core/models/location.py:57
+msgid "locations"
+msgstr "établissements"
+
+#: core/models/invitation.py:52 core/models/membership.py:45
+#: core/models/membership.py:91
+msgid "created by"
+msgstr "créé par"
+
+#: core/models/invitation.py:60
+#, fuzzy
+#| msgid "created by"
+msgid "revoked by"
+msgstr "créé par"
+
+#: core/models/invitation.py:63
+msgid "expires at"
+msgstr ""
+
+#: core/models/invitation.py:66
+msgid "accepted at"
+msgstr ""
+
+#: core/models/invitation.py:69
+msgid "revoked at"
+msgstr ""
+
+#: core/models/invitation.py:78
+#, fuzzy
+#| msgid "organization"
+msgid "invitation"
+msgstr "organisation"
+
+#: core/models/invitation.py:79
+#, fuzzy
+#| msgid "organizations"
+msgid "invitations"
+msgstr "organisations"
 
 #: core/models/location.py:30 core/models/organization.py:34
 msgid "name"
@@ -92,10 +205,6 @@ msgstr "actif"
 msgid "location"
 msgstr "établissement"
 
-#: core/models/location.py:57
-msgid "locations"
-msgstr "établissements"
-
 #: core/models/membership.py:14
 msgid "Admin"
 msgstr "Administrateur"
@@ -108,14 +217,6 @@ msgstr "Opérateur"
 #: core/models/user.py:87
 msgid "user"
 msgstr "utilisateur"
-
-#: core/models/membership.py:34
-msgid "role"
-msgstr "rôle"
-
-#: core/models/membership.py:45 core/models/membership.py:91
-msgid "created by"
-msgstr "créé par"
 
 #: core/models/membership.py:51
 msgid "organization membership"
@@ -157,10 +258,6 @@ msgstr "devise par défaut"
 msgid "default language"
 msgstr "langue par défaut"
 
-#: core/models/organization.py:64
-msgid "VAT number"
-msgstr "numéro de TVA"
-
 #: core/models/organization.py:67
 msgid "billing email"
 msgstr "e-mail de facturation"
@@ -180,10 +277,6 @@ msgstr "Le superutilisateur doit avoir is_staff=True."
 #: core/models/user.py:48
 msgid "Superuser must have is_superuser=True."
 msgstr "Le superutilisateur doit avoir is_superuser=True."
-
-#: core/models/user.py:57
-msgid "email"
-msgstr "e-mail"
 
 #: core/models/user.py:60
 msgid "first name"
@@ -226,6 +319,10 @@ msgstr ""
 "L'URL ne peut contenir que des lettres minuscules, des chiffres et des "
 "traits d'union."
 
+#: core/views/auth.py:54
+msgid "This email or organisation slug is already in use."
+msgstr ""
+
 #: core/views/design.py:36
 msgid "Name"
 msgstr ""
@@ -233,12 +330,6 @@ msgstr ""
 #: core/views/design.py:36
 msgid "Your full name."
 msgstr ""
-
-#: core/views/design.py:37
-#, fuzzy
-#| msgid "email"
-msgid "Email"
-msgstr "e-mail"
 
 #: core/views/design.py:39
 msgid "Role"
@@ -267,8 +358,168 @@ msgstr "langue par défaut"
 msgid "Profile"
 msgstr ""
 
-#: templates/_partials/user_menu.html:3
+#: templates/_partials/user_menu.html:3 templates/auth/org_picker.html:28
 msgid "Sign out"
+msgstr ""
+
+#: templates/auth/login.html:4 templates/auth/login.html:7
+#: templates/auth/login.html:14 templates/auth/verify_already.html:9
+#: templates/auth/verify_failed.html:9
+msgid "Sign in"
+msgstr ""
+
+#: templates/auth/login.html:22
+msgid "Resend verification email"
+msgstr ""
+
+#: templates/auth/login.html:26
+msgid "Forgot password?"
+msgstr ""
+
+#: templates/auth/login.html:27
+msgid "Create an account"
+msgstr ""
+
+#: templates/auth/org_picker.html:4 templates/auth/org_picker.html:8
+#, fuzzy
+#| msgid "organization"
+msgid "Choose an organisation"
+msgstr "organisation"
+
+#: templates/auth/org_picker.html:24
+#, fuzzy
+#| msgid "organizations"
+msgid "No organisations"
+msgstr "organisations"
+
+#: templates/auth/org_picker.html:25
+msgid "Your account isn't linked to any active organisation."
+msgstr ""
+
+#: templates/auth/password_reset_confirm.html:4
+#: templates/auth/password_reset_confirm.html:7
+msgid "Choose a new password"
+msgstr ""
+
+#: templates/auth/password_reset_confirm.html:13
+msgid "Set new password"
+msgstr ""
+
+#: templates/auth/password_reset_failed.html:4
+msgid "Reset link invalid"
+msgstr ""
+
+#: templates/auth/password_reset_failed.html:7
+msgid "This link is invalid or has expired"
+msgstr ""
+
+#: templates/auth/password_reset_failed.html:8
+msgid "Reset links expire after 1 hour. Request a new one to continue."
+msgstr ""
+
+#: templates/auth/password_reset_failed.html:9
+msgid "Request a new link"
+msgstr ""
+
+#: templates/auth/password_reset_request.html:4
+#: templates/auth/password_reset_request.html:7
+#: templates/email/password_reset.html:7
+msgid "Reset password"
+msgstr ""
+
+#: templates/auth/password_reset_request.html:8
+msgid ""
+"Enter the email for your account and we'll send a link to set a new password."
+msgstr ""
+
+#: templates/auth/password_reset_request.html:13
+msgid "Send reset link"
+msgstr ""
+
+#: templates/auth/password_reset_request.html:17
+#: templates/auth/password_reset_sent.html:9
+msgid "Back to sign in"
+msgstr ""
+
+#: templates/auth/password_reset_sent.html:4
+#: templates/auth/password_reset_sent.html:7 templates/auth/signup_done.html:4
+#: templates/auth/signup_done.html:7 templates/auth/verify_resent.html:4
+#: templates/auth/verify_resent.html:7
+msgid "Check your inbox"
+msgstr ""
+
+#: templates/auth/password_reset_sent.html:8
+msgid ""
+"If an account exists for that email, we've sent a link to reset your "
+"password. The link expires in 1 hour."
+msgstr ""
+
+#: templates/auth/signup.html:4
+msgid "Create your account"
+msgstr ""
+
+#: templates/auth/signup.html:7
+#, fuzzy
+#| msgid "organization"
+msgid "Create your organisation"
+msgstr "organisation"
+
+#: templates/auth/signup.html:31
+#, fuzzy
+#| msgid "URL must contain only lowercase letters, digits, and hyphens."
+msgid "Lowercase letters, numbers, and dashes."
+msgstr ""
+"L'URL ne peut contenir que des lettres minuscules, des chiffres et des "
+"traits d'union."
+
+#: templates/auth/signup.html:33
+msgid "Format: BE0123456789"
+msgstr ""
+
+#: templates/auth/signup.html:37
+msgid "Create account"
+msgstr ""
+
+#: templates/auth/signup_done.html:8
+msgid ""
+"We've sent a verification link to your email. Click it to activate your "
+"account."
+msgstr ""
+
+#: templates/auth/signup_done.html:9
+msgid "The link is valid for 7 days."
+msgstr ""
+
+#: templates/auth/verify_already.html:4 templates/auth/verify_already.html:7
+msgid "Already verified"
+msgstr ""
+
+#: templates/auth/verify_already.html:8
+msgid "Your email is already verified - this link has been used."
+msgstr ""
+
+#: templates/auth/verify_failed.html:4
+msgid "Verification link invalid"
+msgstr ""
+
+#: templates/auth/verify_failed.html:7
+msgid "Verification link invalid or expired"
+msgstr ""
+
+#: templates/auth/verify_failed.html:8
+msgid ""
+"This verification link can't be used. It may have expired (links are valid "
+"for 7 days), been tampered with, or already replaced by a newer one."
+msgstr ""
+
+#: templates/auth/verify_failed.html:9
+msgid "to request a new verification email."
+msgstr ""
+
+#: templates/auth/verify_resent.html:8
+msgid ""
+"If an unverified account exists for that email, we've sent a fresh "
+"verification link."
 msgstr ""
 
 #: templates/base_org.html:7 templates/base_picker.html:7
@@ -281,20 +532,75 @@ msgstr ""
 msgid "Sent by %(brand)s."
 msgstr ""
 
+#: templates/email/invitation.html:3 templates/email/invitation.txt:3
+#: templates/email/invitation_revoked.html:3
+#: templates/email/invitation_revoked.txt:3
 #: templates/email/password_reset.html:3 templates/email/password_reset.txt:3
 #: templates/email/verify.html:3 templates/email/verify.txt:3
 #, python-format
 msgid "Hi %(name)s,"
 msgstr ""
 
+#: templates/email/invitation.html:4 templates/email/invitation.txt:5
+#, python-format
+msgid "%(inviter)s invited you to join %(org)s on %(brand)s."
+msgstr ""
+
+#: templates/email/invitation.html:5 templates/email/invitation.txt:7
+msgid "You'll join as an administrator."
+msgstr ""
+
+#: templates/email/invitation.html:5 templates/email/invitation.txt:7
+msgid "You'll join as an operator."
+msgstr ""
+
+#: templates/email/invitation.html:7 templates/email/invitation.txt:9
+msgid "Your assigned locations:"
+msgstr ""
+
+#: templates/email/invitation.html:14
+msgid "Accept invitation"
+msgstr ""
+
+#: templates/email/invitation.html:17 templates/email/invitation.txt:16
+#: templates/email/verify.html:10 templates/email/verify.txt:9
+#, python-format
+msgid "This link expires in %(days)s day."
+msgid_plural "This link expires in %(days)s days."
+msgstr[0] ""
+msgstr[1] ""
+
+#: templates/email/invitation.html:20 templates/email/invitation.txt:18
+#, python-format
+msgid "Sent for %(org)s. "
+msgstr ""
+
+#: templates/email/invitation.txt:12
+msgid "Accept your invitation:"
+msgstr ""
+
+#: templates/email/invitation_revoked.html:4
+#: templates/email/invitation_revoked.txt:5
+#, python-format
+msgid ""
+"Your invitation to join %(org)s on %(brand)s has been withdrawn. No action "
+"is needed."
+msgstr ""
+
+#: templates/email/invitation_revoked_subject.txt:1
+#, python-format
+msgid "Your invitation to %(org)s was withdrawn"
+msgstr ""
+
+#: templates/email/invitation_subject.txt:1
+#, python-format
+msgid "You're invited to %(org)s on %(brand)s"
+msgstr ""
+
 #: templates/email/password_reset.html:4
 msgid ""
 "We received a request to reset your password. Use the button below to choose "
 "a new one:"
-msgstr ""
-
-#: templates/email/password_reset.html:7
-msgid "Reset password"
 msgstr ""
 
 #: templates/email/password_reset.html:10 templates/email/password_reset.txt:9
@@ -321,13 +627,6 @@ msgstr ""
 #: templates/email/verify.html:7
 msgid "Verify email"
 msgstr ""
-
-#: templates/email/verify.html:10 templates/email/verify.txt:9
-#, python-format
-msgid "This link expires in %(days)s day."
-msgid_plural "This link expires in %(days)s days."
-msgstr[0] ""
-msgstr[1] ""
 
 #: templates/email/verify.html:13 templates/email/verify.txt:11
 #, python-format

--- a/locale/nl_BE/LC_MESSAGES/django.po
+++ b/locale/nl_BE/LC_MESSAGES/django.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: rapido\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-05-02 10:51+0000\n"
+"POT-Creation-Date: 2026-05-03 00:28+0000\n"
 "PO-Revision-Date: 2026-05-01 11:19+0000\n"
 "Language-Team: Dutch (Belgium)\n"
 "Language: nl_BE\n"
@@ -49,14 +49,36 @@ msgstr "Persoonlijke informatie"
 msgid "Permissions"
 msgstr "Rechten"
 
-#: core/forms/signup.py:16 core/views/design.py:37
+#: core/forms/auth.py:14 core/forms/auth.py:58 core/forms/signup.py:16
+#: core/views/design.py:37
 #, fuzzy
 #| msgid "email"
 msgid "Email"
 msgstr "e-mail"
 
-#: core/forms/signup.py:20
+#: core/forms/auth.py:18 core/forms/signup.py:20
 msgid "Password"
+msgstr ""
+
+#: core/forms/auth.py:40
+msgid "Invalid email or password."
+msgstr ""
+
+#: core/forms/auth.py:45
+msgid ""
+"Your email isn't verified yet. Check your inbox for the verification link."
+msgstr ""
+
+#: core/forms/auth.py:68
+msgid "New password"
+msgstr ""
+
+#: core/forms/auth.py:73
+msgid "Confirm password"
+msgstr ""
+
+#: core/forms/auth.py:89
+msgid "Passwords do not match."
 msgstr ""
 
 #: core/forms/signup.py:25
@@ -93,10 +115,57 @@ msgstr ""
 msgid "An account with this email already exists."
 msgstr ""
 
-#: core/models/location.py:27 core/models/membership.py:29
-#: core/models/organization.py:76
+#: core/models/invitation.py:32 core/models/location.py:27
+#: core/models/membership.py:29 core/models/organization.py:76
 msgid "organization"
 msgstr "organisatie"
+
+#: core/models/invitation.py:35 core/models/user.py:57
+msgid "email"
+msgstr "e-mail"
+
+#: core/models/invitation.py:40 core/models/membership.py:34
+msgid "role"
+msgstr "rol"
+
+#: core/models/invitation.py:46 core/models/location.py:57
+msgid "locations"
+msgstr "vestigingen"
+
+#: core/models/invitation.py:52 core/models/membership.py:45
+#: core/models/membership.py:91
+msgid "created by"
+msgstr "aangemaakt door"
+
+#: core/models/invitation.py:60
+#, fuzzy
+#| msgid "created by"
+msgid "revoked by"
+msgstr "aangemaakt door"
+
+#: core/models/invitation.py:63
+msgid "expires at"
+msgstr ""
+
+#: core/models/invitation.py:66
+msgid "accepted at"
+msgstr ""
+
+#: core/models/invitation.py:69
+msgid "revoked at"
+msgstr ""
+
+#: core/models/invitation.py:78
+#, fuzzy
+#| msgid "organization"
+msgid "invitation"
+msgstr "organisatie"
+
+#: core/models/invitation.py:79
+#, fuzzy
+#| msgid "organizations"
+msgid "invitations"
+msgstr "organisaties"
 
 #: core/models/location.py:30 core/models/organization.py:34
 msgid "name"
@@ -136,10 +205,6 @@ msgstr "actief"
 msgid "location"
 msgstr "vestiging"
 
-#: core/models/location.py:57
-msgid "locations"
-msgstr "vestigingen"
-
 #: core/models/membership.py:14
 msgid "Admin"
 msgstr "Beheerder"
@@ -152,14 +217,6 @@ msgstr "Operator"
 #: core/models/user.py:87
 msgid "user"
 msgstr "gebruiker"
-
-#: core/models/membership.py:34
-msgid "role"
-msgstr "rol"
-
-#: core/models/membership.py:45 core/models/membership.py:91
-msgid "created by"
-msgstr "aangemaakt door"
 
 #: core/models/membership.py:51
 msgid "organization membership"
@@ -221,10 +278,6 @@ msgstr "Superuser moet is_staff=True hebben."
 msgid "Superuser must have is_superuser=True."
 msgstr "Superuser moet is_superuser=True hebben."
 
-#: core/models/user.py:57
-msgid "email"
-msgstr "e-mail"
-
 #: core/models/user.py:60
 msgid "first name"
 msgstr "voornaam"
@@ -264,7 +317,7 @@ msgstr "Ongeldige valutacode. Ondersteunde valuta's zijn: %(currencies)s."
 msgid "URL must contain only lowercase letters, digits, and hyphens."
 msgstr "URL mag alleen kleine letters, cijfers en koppeltekens bevatten."
 
-#: core/views/auth.py:32
+#: core/views/auth.py:54
 msgid "This email or organisation slug is already in use."
 msgstr ""
 
@@ -303,8 +356,100 @@ msgstr "standaardtaal"
 msgid "Profile"
 msgstr ""
 
-#: templates/_partials/user_menu.html:3
+#: templates/_partials/user_menu.html:3 templates/auth/org_picker.html:28
 msgid "Sign out"
+msgstr ""
+
+#: templates/auth/login.html:4 templates/auth/login.html:7
+#: templates/auth/login.html:14 templates/auth/verify_already.html:9
+#: templates/auth/verify_failed.html:9
+msgid "Sign in"
+msgstr ""
+
+#: templates/auth/login.html:22
+msgid "Resend verification email"
+msgstr ""
+
+#: templates/auth/login.html:26
+msgid "Forgot password?"
+msgstr ""
+
+#: templates/auth/login.html:27
+msgid "Create an account"
+msgstr ""
+
+#: templates/auth/org_picker.html:4 templates/auth/org_picker.html:8
+#, fuzzy
+#| msgid "organization"
+msgid "Choose an organisation"
+msgstr "organisatie"
+
+#: templates/auth/org_picker.html:24
+#, fuzzy
+#| msgid "organizations"
+msgid "No organisations"
+msgstr "organisaties"
+
+#: templates/auth/org_picker.html:25
+msgid "Your account isn't linked to any active organisation."
+msgstr ""
+
+#: templates/auth/password_reset_confirm.html:4
+#: templates/auth/password_reset_confirm.html:7
+msgid "Choose a new password"
+msgstr ""
+
+#: templates/auth/password_reset_confirm.html:13
+msgid "Set new password"
+msgstr ""
+
+#: templates/auth/password_reset_failed.html:4
+msgid "Reset link invalid"
+msgstr ""
+
+#: templates/auth/password_reset_failed.html:7
+msgid "This link is invalid or has expired"
+msgstr ""
+
+#: templates/auth/password_reset_failed.html:8
+msgid "Reset links expire after 1 hour. Request a new one to continue."
+msgstr ""
+
+#: templates/auth/password_reset_failed.html:9
+msgid "Request a new link"
+msgstr ""
+
+#: templates/auth/password_reset_request.html:4
+#: templates/auth/password_reset_request.html:7
+#: templates/email/password_reset.html:7
+msgid "Reset password"
+msgstr ""
+
+#: templates/auth/password_reset_request.html:8
+msgid ""
+"Enter the email for your account and we'll send a link to set a new password."
+msgstr ""
+
+#: templates/auth/password_reset_request.html:13
+msgid "Send reset link"
+msgstr ""
+
+#: templates/auth/password_reset_request.html:17
+#: templates/auth/password_reset_sent.html:9
+msgid "Back to sign in"
+msgstr ""
+
+#: templates/auth/password_reset_sent.html:4
+#: templates/auth/password_reset_sent.html:7 templates/auth/signup_done.html:4
+#: templates/auth/signup_done.html:7 templates/auth/verify_resent.html:4
+#: templates/auth/verify_resent.html:7
+msgid "Check your inbox"
+msgstr ""
+
+#: templates/auth/password_reset_sent.html:8
+msgid ""
+"If an account exists for that email, we've sent a link to reset your "
+"password. The link expires in 1 hour."
 msgstr ""
 
 #: templates/auth/signup.html:4
@@ -317,22 +462,18 @@ msgstr ""
 msgid "Create your organisation"
 msgstr "organisatie"
 
-#: templates/auth/signup.html:14
+#: templates/auth/signup.html:31
 #, fuzzy
 #| msgid "URL must contain only lowercase letters, digits, and hyphens."
 msgid "Lowercase letters, numbers, and dashes."
 msgstr "URL mag alleen kleine letters, cijfers en koppeltekens bevatten."
 
-#: templates/auth/signup.html:16
+#: templates/auth/signup.html:33
 msgid "Format: BE0123456789"
 msgstr ""
 
-#: templates/auth/signup.html:20
+#: templates/auth/signup.html:37
 msgid "Create account"
-msgstr ""
-
-#: templates/auth/signup_done.html:4 templates/auth/signup_done.html:7
-msgid "Check your inbox"
 msgstr ""
 
 #: templates/auth/signup_done.html:8
@@ -345,6 +486,38 @@ msgstr ""
 msgid "The link is valid for 7 days."
 msgstr ""
 
+#: templates/auth/verify_already.html:4 templates/auth/verify_already.html:7
+msgid "Already verified"
+msgstr ""
+
+#: templates/auth/verify_already.html:8
+msgid "Your email is already verified - this link has been used."
+msgstr ""
+
+#: templates/auth/verify_failed.html:4
+msgid "Verification link invalid"
+msgstr ""
+
+#: templates/auth/verify_failed.html:7
+msgid "Verification link invalid or expired"
+msgstr ""
+
+#: templates/auth/verify_failed.html:8
+msgid ""
+"This verification link can't be used. It may have expired (links are valid "
+"for 7 days), been tampered with, or already replaced by a newer one."
+msgstr ""
+
+#: templates/auth/verify_failed.html:9
+msgid "to request a new verification email."
+msgstr ""
+
+#: templates/auth/verify_resent.html:8
+msgid ""
+"If an unverified account exists for that email, we've sent a fresh "
+"verification link."
+msgstr ""
+
 #: templates/base_org.html:7 templates/base_picker.html:7
 #: templates/base_public.html:7
 msgid "Skip to content"
@@ -355,20 +528,77 @@ msgstr ""
 msgid "Sent by %(brand)s."
 msgstr ""
 
+#: templates/email/invitation.html:3 templates/email/invitation.txt:3
+#: templates/email/invitation_revoked.html:3
+#: templates/email/invitation_revoked.txt:3
 #: templates/email/password_reset.html:3 templates/email/password_reset.txt:3
 #: templates/email/verify.html:3 templates/email/verify.txt:3
 #, python-format
 msgid "Hi %(name)s,"
 msgstr ""
 
+#: templates/email/invitation.html:4 templates/email/invitation.txt:5
+#, python-format
+msgid "%(inviter)s invited you to join %(org)s on %(brand)s."
+msgstr ""
+
+#: templates/email/invitation.html:5 templates/email/invitation.txt:7
+msgid "You'll join as an administrator."
+msgstr ""
+
+#: templates/email/invitation.html:5 templates/email/invitation.txt:7
+msgid "You'll join as an operator."
+msgstr ""
+
+#: templates/email/invitation.html:7 templates/email/invitation.txt:9
+msgid "Your assigned locations:"
+msgstr ""
+
+#: templates/email/invitation.html:14
+msgid "Accept invitation"
+msgstr ""
+
+#: templates/email/invitation.html:17 templates/email/invitation.txt:16
+#: templates/email/verify.html:10 templates/email/verify.txt:9
+#, python-format
+msgid "This link expires in %(days)s day."
+msgid_plural "This link expires in %(days)s days."
+msgstr[0] ""
+msgstr[1] ""
+
+#: templates/email/invitation.html:20 templates/email/invitation.txt:18
+#, python-format
+msgid "Sent for %(org)s. "
+msgstr ""
+
+#: templates/email/invitation.txt:12
+#, fuzzy
+#| msgid "organization"
+msgid "Accept your invitation:"
+msgstr "organisatie"
+
+#: templates/email/invitation_revoked.html:4
+#: templates/email/invitation_revoked.txt:5
+#, python-format
+msgid ""
+"Your invitation to join %(org)s on %(brand)s has been withdrawn. No action "
+"is needed."
+msgstr ""
+
+#: templates/email/invitation_revoked_subject.txt:1
+#, python-format
+msgid "Your invitation to %(org)s was withdrawn"
+msgstr ""
+
+#: templates/email/invitation_subject.txt:1
+#, python-format
+msgid "You're invited to %(org)s on %(brand)s"
+msgstr ""
+
 #: templates/email/password_reset.html:4
 msgid ""
 "We received a request to reset your password. Use the button below to choose "
 "a new one:"
-msgstr ""
-
-#: templates/email/password_reset.html:7
-msgid "Reset password"
 msgstr ""
 
 #: templates/email/password_reset.html:10 templates/email/password_reset.txt:9
@@ -395,13 +625,6 @@ msgstr ""
 #: templates/email/verify.html:7
 msgid "Verify email"
 msgstr ""
-
-#: templates/email/verify.html:10 templates/email/verify.txt:9
-#, python-format
-msgid "This link expires in %(days)s day."
-msgid_plural "This link expires in %(days)s days."
-msgstr[0] ""
-msgstr[1] ""
 
 #: templates/email/verify.html:13 templates/email/verify.txt:11
 #, python-format

--- a/templates/email/invitation.html
+++ b/templates/email/invitation.html
@@ -1,0 +1,20 @@
+{% extends "email/_base.html" %}{% load i18n %}
+{% block body %}
+  <p>{% blocktrans with name=invitee_email %}Hi {{ name }},{% endblocktrans %}</p>
+  <p>{% blocktrans with inviter=inviter_name org=organization_name %}{{ inviter }} invited you to join {{ org }} on {{ brand }}.{% endblocktrans %}</p>
+  <p>{% if role == "ADMIN" %}{% trans "You'll join as an administrator." %}{% else %}{% trans "You'll join as an operator." %}{% endif %}</p>
+  {% if locations %}
+  <p style="margin:0 0 8px 0;">{% trans "Your assigned locations:" %}</p>
+  <ul style="margin:0 0 16px 20px;padding:0;">
+    {% for loc in locations %}<li>{{ loc.name }}</li>{% endfor %}
+  </ul>
+  {% endif %}
+  <p style="margin:24px 0;">
+    <a href="{{ accept_url }}" style="display:inline-block;padding:10px 18px;background:#111;color:#fff;text-decoration:none;border-radius:4px;">
+      {% trans "Accept invitation" %}
+    </a>
+  </p>
+  <p style="font-size:13px;color:#666;">{% blocktrans count days=7 %}This link expires in {{ days }} day.{% plural %}This link expires in {{ days }} days.{% endblocktrans %}</p>
+  <p style="font-size:13px;color:#666;word-break:break-all;">{{ accept_url }}</p>
+{% endblock %}
+{% block footer_extra %}{% blocktrans with org=organization_name %}Sent for {{ org }}. {% endblocktrans %}{% endblock %}

--- a/templates/email/invitation.html
+++ b/templates/email/invitation.html
@@ -2,7 +2,7 @@
 {% block body %}
   <p>{% blocktrans with name=invitee_email %}Hi {{ name }},{% endblocktrans %}</p>
   <p>{% blocktrans with inviter=inviter_name org=organization_name %}{{ inviter }} invited you to join {{ org }} on {{ brand }}.{% endblocktrans %}</p>
-  <p>{% if role == "ADMIN" %}{% trans "You'll join as an administrator." %}{% else %}{% trans "You'll join as an operator." %}{% endif %}</p>
+  <p>{% if role == "ADMIN" %}{% trans "You'll join as an administrator." %}{% elif role == "OPERATOR" %}{% trans "You'll join as an operator." %}{% endif %}</p>
   {% if locations %}
   <p style="margin:0 0 8px 0;">{% trans "Your assigned locations:" %}</p>
   <ul style="margin:0 0 16px 20px;padding:0;">

--- a/templates/email/invitation.txt
+++ b/templates/email/invitation.txt
@@ -4,7 +4,7 @@
 
 {% blocktrans with inviter=inviter_name org=organization_name %}{{ inviter }} invited you to join {{ org }} on {{ brand }}.{% endblocktrans %}
 
-{% if role == "ADMIN" %}{% trans "You'll join as an administrator." %}{% else %}{% trans "You'll join as an operator." %}{% endif %}
+{% if role == "ADMIN" %}{% trans "You'll join as an administrator." %}{% elif role == "OPERATOR" %}{% trans "You'll join as an operator." %}{% endif %}
 {% if locations %}
 {% trans "Your assigned locations:" %}
 {% for loc in locations %}- {{ loc.name }}

--- a/templates/email/invitation.txt
+++ b/templates/email/invitation.txt
@@ -1,0 +1,18 @@
+{% extends "email/_base.txt" %}{% load i18n %}
+{% block body %}
+{% blocktrans with name=invitee_email %}Hi {{ name }},{% endblocktrans %}
+
+{% blocktrans with inviter=inviter_name org=organization_name %}{{ inviter }} invited you to join {{ org }} on {{ brand }}.{% endblocktrans %}
+
+{% if role == "ADMIN" %}{% trans "You'll join as an administrator." %}{% else %}{% trans "You'll join as an operator." %}{% endif %}
+{% if locations %}
+{% trans "Your assigned locations:" %}
+{% for loc in locations %}- {{ loc.name }}
+{% endfor %}{% endif %}
+{% trans "Accept your invitation:" %}
+
+{{ accept_url }}
+
+{% blocktrans count days=7 %}This link expires in {{ days }} day.{% plural %}This link expires in {{ days }} days.{% endblocktrans %}
+{% endblock %}
+{% block footer_extra %}{% blocktrans with org=organization_name %}Sent for {{ org }}. {% endblocktrans %}{% endblock %}

--- a/templates/email/invitation_revoked.html
+++ b/templates/email/invitation_revoked.html
@@ -1,0 +1,5 @@
+{% extends "email/_base.html" %}{% load i18n %}
+{% block body %}
+  <p>{% blocktrans with name=invitee_email %}Hi {{ name }},{% endblocktrans %}</p>
+  <p>{% blocktrans with org=organization_name %}Your invitation to join {{ org }} on {{ brand }} has been withdrawn. No action is needed.{% endblocktrans %}</p>
+{% endblock %}

--- a/templates/email/invitation_revoked.txt
+++ b/templates/email/invitation_revoked.txt
@@ -1,0 +1,6 @@
+{% extends "email/_base.txt" %}{% load i18n %}
+{% block body %}
+{% blocktrans with name=invitee_email %}Hi {{ name }},{% endblocktrans %}
+
+{% blocktrans with org=organization_name %}Your invitation to join {{ org }} on {{ brand }} has been withdrawn. No action is needed.{% endblocktrans %}
+{% endblock %}

--- a/templates/email/invitation_revoked_subject.txt
+++ b/templates/email/invitation_revoked_subject.txt
@@ -1,0 +1,1 @@
+{% load i18n %}{% blocktrans with org=organization_name %}Your invitation to {{ org }} was withdrawn{% endblocktrans %}

--- a/templates/email/invitation_subject.txt
+++ b/templates/email/invitation_subject.txt
@@ -1,0 +1,1 @@
+{% load i18n %}{% blocktrans with org=organization_name %}You're invited to {{ org }} on {{ brand }}{% endblocktrans %}

--- a/tests/test_core_services_invitation.py
+++ b/tests/test_core_services_invitation.py
@@ -186,8 +186,14 @@ def test_create_invitation_fires_email_on_commit(
         args, kwargs = send.call_args
         assert args == ("email/invitation",)
         assert kwargs["language"] == "nl-BE"
-        assert kwargs["context"]["org_name"] == inv.organization.name
-        assert kwargs["context"]["accept_url"].startswith("http")
+        ctx = kwargs["context"]
+        assert ctx["organization_name"] == inv.organization.name
+        assert ctx["accept_url"].startswith("http")
+        assert ctx["invitee_email"] == "invitee@example.be"
+        assert ctx["role"] == Role.ADMIN
+        assert ctx["locations"] == []
+        assert ctx["expires_at"] == inv.expires_at
+        assert ctx["inviter_name"]
 
 
 @pytest.mark.django_db

--- a/tests/test_core_services_invitation.py
+++ b/tests/test_core_services_invitation.py
@@ -197,6 +197,42 @@ def test_create_invitation_fires_email_on_commit(
 
 
 @pytest.mark.django_db
+def test_create_invitation_email_uses_existing_user_preferred_language(
+    django_capture_on_commit_callbacks: _Capture,
+) -> None:
+    UserFactory(email="invitee@example.be", preferred_language="fr-BE")
+    with patch("core.services.invitation.send_templated") as send:
+        with django_capture_on_commit_callbacks(execute=True):
+            create_invitation(
+                organization=OrganizationFactory(default_language="nl-BE"),
+                email="invitee@example.be",
+                role=Role.ADMIN,
+                locations=[],
+                created_by=UserFactory(),
+            )
+        _, kwargs = send.call_args
+        assert kwargs["language"] == "fr-BE"
+
+
+@pytest.mark.django_db
+def test_create_invitation_email_falls_back_to_org_language_when_user_blank(
+    django_capture_on_commit_callbacks: _Capture,
+) -> None:
+    UserFactory(email="invitee@example.be", preferred_language="")
+    with patch("core.services.invitation.send_templated") as send:
+        with django_capture_on_commit_callbacks(execute=True):
+            create_invitation(
+                organization=OrganizationFactory(default_language="nl-BE"),
+                email="invitee@example.be",
+                role=Role.ADMIN,
+                locations=[],
+                created_by=UserFactory(),
+            )
+        _, kwargs = send.call_args
+        assert kwargs["language"] == "nl-BE"
+
+
+@pytest.mark.django_db
 def test_create_invitation_email_failure_is_logged_and_swallowed(
     django_capture_on_commit_callbacks: _Capture,
     caplog: pytest.LogCaptureFixture,

--- a/tests/test_email_invitation.py
+++ b/tests/test_email_invitation.py
@@ -1,0 +1,131 @@
+from datetime import timedelta
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+from django.conf import settings
+from django.utils import timezone
+
+from core.models import User
+from core.services.mail import send_templated
+
+
+def _user(email: str = "invitee@example.be", lang: str = "en-us") -> User:
+    return User(email=email, preferred_language=lang)
+
+
+def _ctx(overrides: dict[str, Any] | None = None) -> dict[str, Any]:
+    base: dict[str, Any] = {
+        "invitee_email": "invitee@example.be",
+        "inviter_name": "Alice Admin",
+        "organization_name": "Cafe Test",
+        "role": "OPERATOR",
+        "locations": [SimpleNamespace(name="Main")],
+        "accept_url": "https://example.test/invite/abc/",
+        "expires_at": timezone.now() + timedelta(days=7),
+    }
+    if overrides:
+        base.update(overrides)
+    return base
+
+
+@pytest.mark.django_db
+def test_invitation_renders_text_and_html(mailoutbox: list) -> None:
+    send_templated("email/invitation", to=_user(), context=_ctx())
+    msg = mailoutbox[0]
+    assert msg.subject
+    assert msg.body
+    assert len(msg.alternatives) == 1
+    html, mime = msg.alternatives[0]
+    assert mime == "text/html"
+    assert str(html)
+
+
+@pytest.mark.django_db
+def test_invitation_html_has_accept_anchor(mailoutbox: list) -> None:
+    ctx = _ctx()
+    send_templated("email/invitation", to=_user(), context=ctx)
+    html = str(mailoutbox[0].alternatives[0][0])
+    assert f'href="{ctx["accept_url"]}"' in html
+
+
+@pytest.mark.django_db
+def test_invitation_brand_appears_in_body(mailoutbox: list) -> None:
+    send_templated("email/invitation", to=_user(), context=_ctx())
+    msg = mailoutbox[0]
+    assert settings.SITE_BRAND in msg.body
+    assert settings.SITE_BRAND in str(msg.alternatives[0][0])
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize("language", ["en-us", "nl-BE", "fr-BE"])
+def test_invitation_renders_in_each_language(
+    mailoutbox: list, language: str
+) -> None:
+    ctx = _ctx()
+    send_templated("email/invitation", to=_user(lang=language), context=ctx)
+    msg = mailoutbox[-1]
+    html = str(msg.alternatives[0][0])
+    assert msg.subject
+    assert ctx["accept_url"] in msg.body
+    assert ctx["accept_url"] in html
+    assert f'lang="{language.lower()}"' in html.lower()
+
+
+@pytest.mark.django_db
+def test_invitation_subject_is_single_line(mailoutbox: list) -> None:
+    send_templated("email/invitation", to=_user(), context=_ctx())
+    subject = mailoutbox[0].subject
+    assert "\n" not in subject
+    assert "\r" not in subject
+
+
+@pytest.mark.django_db
+def test_invitation_admin_omits_locations_section(mailoutbox: list) -> None:
+    send_templated(
+        "email/invitation",
+        to=_user(),
+        context=_ctx({"role": "ADMIN", "locations": []}),
+    )
+    msg = mailoutbox[0]
+    html = str(msg.alternatives[0][0])
+    assert "Your assigned locations" not in msg.body
+    assert "Your assigned locations" not in html
+
+
+@pytest.mark.django_db
+def test_invitation_operator_lists_location_names(mailoutbox: list) -> None:
+    locations = [
+        SimpleNamespace(name="Brussels"),
+        SimpleNamespace(name="Ghent"),
+    ]
+    send_templated(
+        "email/invitation",
+        to=_user(),
+        context=_ctx({"role": "OPERATOR", "locations": locations}),
+    )
+    msg = mailoutbox[0]
+    html = str(msg.alternatives[0][0])
+    assert "Brussels" in msg.body
+    assert "Ghent" in msg.body
+    assert "Brussels" in html
+    assert "Ghent" in html
+
+
+@pytest.mark.django_db
+def test_invitation_revoked_renders(mailoutbox: list) -> None:
+    send_templated(
+        "email/invitation_revoked",
+        to=_user(),
+        context={
+            "invitee_email": "invitee@example.be",
+            "organization_name": "Cafe Test",
+        },
+    )
+    msg = mailoutbox[0]
+    assert msg.subject
+    assert msg.body
+    html = str(msg.alternatives[0][0])
+    assert "https://example.test/invite/" not in msg.body
+    assert "https://example.test/invite/" not in html
+    assert "Cafe Test" in msg.body


### PR DESCRIPTION
## Summary
- Adds `templates/email/invitation.{txt,html}` + `invitation_subject.txt`, extending `email/_base` and mirroring the `verify` / `password_reset` patterns from epic 2b. Greeting, role line (admin/operator), optional locations list, accept-CTA button, 7-day expiry, `Sent for {org}` footer.
- Adds `templates/email/invitation_revoked.{txt,html}` + subject. Render-only; no service wiring (issue marks it optional).
- Extends `_send_invitation_email` context to the full set listed in the issue: `invitee_email`, `inviter_name`, `organization_name`, `role`, `locations`, `accept_url`, `expires_at`. Renames the `org_name` context key to `organization_name`; the existing service test updated accordingly.
- New tests in `tests/test_email_invitation.py` (10 cases) covering: text+html parts, accept-anchor presence (`<a href="{{ accept_url }}">`), brand prefix, en/nl/fr render, single-line subject, ADMIN omits locations section, OPERATOR lists location names, revoked smoke test.
- `manage.py makemessages -l nl_BE -l fr_BE -l de_DE` regenerated the catalogs. **Heads-up:** the .po diffs are larger than the strings introduced here because the catalogs were already stale for several pre-existing strings (login form, profile, etc.). Bringing them up to date in this PR keeps things tidy; happy to split if preferred.

Closes #75

## Test plan
- [x] `uv run pytest tests/test_email_invitation.py` — 10/10 pass
- [x] `uv run pytest tests/test_core_services_invitation.py` — 29/29 pass (now exercises a real template instead of the swallowed-template-missing path)
- [x] `uv run pytest` — full suite 373 passed, 1 skipped
- [x] `manage.py makemessages -l nl_BE -l fr_BE -l de_DE` — new msgids extracted (`"%(inviter)s invited you to join %(org)s on %(brand)s."`, `"Accept invitation"`, `"Your assigned locations:"`, `"You'll join as an administrator."` / `"as an operator."`, `"Your invitation to %(org)s was withdrawn"`, etc.)
- [ ] Manual smoke (reviewer): `manage.py shell` -> `create_invitation(...)` with `EMAIL_BACKEND=django.core.mail.backends.console.EmailBackend` and inspect the rendered text+html for an ADMIN (no locations) and an OPERATOR (with locations); repeat with `language="nl_BE"` to confirm the locale switch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)