### PR TITLE
feat(2c): locations management UI (closes #78)

### DIFF
--- a/core/forms/location.py
+++ b/core/forms/location.py
@@ -31,9 +31,11 @@ class LocationForm(forms.ModelForm):
         if editing:
             self.fields.pop("slug", None)
 
-    def clean_slug(self) -> str:
-        slug = self.cleaned_data["slug"]
-        qs = Location.tenant_objects.for_organization(  # type: ignore[attr-defined]
+    def clean_slug(self) -> str | None:
+        slug = self.cleaned_data.get("slug")
+        if not slug:
+            return slug
+        qs = Location.tenant_objects.for_organization(
             self._organization
         ).filter(slug=slug)
         if self.instance.pk is not None:

--- a/core/forms/location.py
+++ b/core/forms/location.py
@@ -1,0 +1,48 @@
+from typing import Any, ClassVar
+
+from django import forms
+from django.core.exceptions import ValidationError
+from django.utils.translation import gettext_lazy as _
+
+from core.models import Location, Organization
+
+
+class LocationForm(forms.ModelForm):
+    class Meta:
+        model = Location
+        fields: ClassVar[list[str]] = [
+            "name",
+            "slug",
+            "street",
+            "postal_code",
+            "city",
+            "phone",
+        ]
+
+    def __init__(
+        self,
+        *args: Any,  # noqa: ANN401
+        organization: Organization,
+        editing: bool = False,
+        **kwargs: Any,  # noqa: ANN401
+    ) -> None:
+        super().__init__(*args, **kwargs)
+        self._organization = organization
+        if editing:
+            self.fields.pop("slug", None)
+
+    def clean_slug(self) -> str:
+        slug = self.cleaned_data["slug"]
+        qs = Location.tenant_objects.for_organization(  # type: ignore[attr-defined]
+            self._organization
+        ).filter(slug=slug)
+        if self.instance.pk is not None:
+            qs = qs.exclude(pk=self.instance.pk)
+        if qs.exists():
+            raise ValidationError(
+                _(
+                    "A location with this URL already exists in this "
+                    "organization."
+                )
+            )
+        return slug

--- a/core/models/location.py
+++ b/core/models/location.py
@@ -10,6 +10,7 @@ from django.db.models.fields import (
 )
 from django.utils.translation import gettext_lazy as _
 
+from core.managers import TenantOwnedManager
 from core.models.base import TimestampedModel
 from core.models.organization import Organization
 from core.utils.ids import uuid7
@@ -49,6 +50,9 @@ class Location(TimestampedModel):
     is_active: BooleanField[bool] = models.BooleanField(
         default=True, verbose_name=_("active")
     )
+
+    objects: ClassVar[models.Manager[Location]] = models.Manager()  # type: ignore[assignment]
+    tenant_objects: ClassVar[TenantOwnedManager] = TenantOwnedManager()
 
     class Meta(TimestampedModel.Meta):
         abstract = False

--- a/core/services/location.py
+++ b/core/services/location.py
@@ -1,0 +1,29 @@
+from django.db import transaction
+
+from core.models import Location
+
+
+def deactivate_location(location: Location) -> None:
+    if not location.is_active:
+        return
+    with transaction.atomic():
+        locked = Location.objects.select_for_update().get(pk=location.pk)
+        if not locked.is_active:
+            return
+        locked.is_active = False
+        locked.save(update_fields=["is_active", "updated_at"])
+        location.is_active = False
+        location.updated_at = locked.updated_at
+
+
+def reactivate_location(location: Location) -> None:
+    if location.is_active:
+        return
+    with transaction.atomic():
+        locked = Location.objects.select_for_update().get(pk=location.pk)
+        if locked.is_active:
+            return
+        locked.is_active = True
+        locked.save(update_fields=["is_active", "updated_at"])
+        location.is_active = True
+        location.updated_at = locked.updated_at

--- a/core/urls.py
+++ b/core/urls.py
@@ -2,7 +2,7 @@ from django.conf import settings
 from django.urls import path
 from django.urls.resolvers import URLPattern
 
-from .views import home
+from .views import home, locations
 from .views.auth import (
     login,
     logout,
@@ -18,7 +18,6 @@ from .views.dashboard import dashboard
 from .views.design import design_kitchen_sink
 from .views.settings import (
     settings_invitations,
-    settings_locations,
     settings_members,
     settings_organization,
 )
@@ -51,8 +50,28 @@ urlpatterns: list[URLPattern] = [
     path(route="o/<slug:slug>/", view=dashboard, name="org_dashboard"),
     path(
         route="o/<slug:slug>/settings/locations/",
-        view=settings_locations,
+        view=locations.list_view,
         name="settings_locations",
+    ),
+    path(
+        route="o/<slug:slug>/settings/locations/new/",
+        view=locations.create,
+        name="settings_locations_create",
+    ),
+    path(
+        route="o/<slug:slug>/settings/locations/<int:pk>/edit/",
+        view=locations.edit,
+        name="settings_locations_edit",
+    ),
+    path(
+        route="o/<slug:slug>/settings/locations/<int:pk>/deactivate/",
+        view=locations.deactivate,
+        name="settings_locations_deactivate",
+    ),
+    path(
+        route="o/<slug:slug>/settings/locations/<int:pk>/reactivate/",
+        view=locations.reactivate,
+        name="settings_locations_reactivate",
     ),
     path(
         route="o/<slug:slug>/settings/members/",

--- a/core/views/locations.py
+++ b/core/views/locations.py
@@ -1,0 +1,107 @@
+from django.http import HttpRequest, HttpResponse
+from django.shortcuts import get_object_or_404, redirect, render
+from django.views.decorators.http import require_POST
+
+from core.decorators import permission_required
+from core.forms.location import LocationForm
+from core.models import Location, Role
+from core.services import location as location_service
+
+
+def _row(request: HttpRequest, location: Location) -> HttpResponse:
+    return render(
+        request,
+        "locations/_row.html",
+        {
+            "organization": request.organization,  # type: ignore[attr-defined]
+            "location": location,
+        },
+    )
+
+
+@permission_required(Role.ADMIN)
+def list_view(request: HttpRequest, slug: str) -> HttpResponse:  # noqa: ARG001
+    locations = Location.tenant_objects.for_request(request).order_by(
+        "-is_active", "name"
+    )
+    return render(
+        request,
+        "locations/list.html",
+        {
+            "organization": request.organization,  # type: ignore[attr-defined]
+            "locations": locations,
+        },
+    )
+
+
+@permission_required(Role.ADMIN)
+def create(request: HttpRequest, slug: str) -> HttpResponse:
+    organization = request.organization  # type: ignore[attr-defined]
+    if request.method == "POST":
+        form = LocationForm(request.POST, organization=organization)
+        if form.is_valid():
+            form.instance.organization = organization
+            form.save()
+            return redirect("core:settings_locations", slug=slug)
+    else:
+        form = LocationForm(organization=organization)
+    return render(
+        request,
+        "locations/create.html",
+        {"organization": organization, "form": form},
+    )
+
+
+@permission_required(Role.ADMIN)
+def edit(request: HttpRequest, slug: str, pk: int) -> HttpResponse:
+    organization = request.organization  # type: ignore[attr-defined]
+    location = get_object_or_404(
+        Location.tenant_objects.for_request(request), pk=pk
+    )
+    if request.method == "POST":
+        form = LocationForm(
+            request.POST,
+            instance=location,
+            organization=organization,
+            editing=True,
+        )
+        if form.is_valid():
+            form.save()
+            return redirect("core:settings_locations", slug=slug)
+    else:
+        form = LocationForm(
+            instance=location, organization=organization, editing=True
+        )
+    return render(
+        request,
+        "locations/edit.html",
+        {
+            "organization": organization,
+            "form": form,
+            "location": location,
+        },
+    )
+
+
+@require_POST
+@permission_required(Role.ADMIN)
+def deactivate(request: HttpRequest, slug: str, pk: int) -> HttpResponse:
+    location = get_object_or_404(
+        Location.tenant_objects.for_request(request), pk=pk
+    )
+    location_service.deactivate_location(location)
+    if request.htmx:  # type: ignore[attr-defined]
+        return _row(request, location)
+    return redirect("core:settings_locations", slug=slug)
+
+
+@require_POST
+@permission_required(Role.ADMIN)
+def reactivate(request: HttpRequest, slug: str, pk: int) -> HttpResponse:
+    location = get_object_or_404(
+        Location.tenant_objects.for_request(request), pk=pk
+    )
+    location_service.reactivate_location(location)
+    if request.htmx:  # type: ignore[attr-defined]
+        return _row(request, location)
+    return redirect("core:settings_locations", slug=slug)

--- a/core/views/settings.py
+++ b/core/views/settings.py
@@ -5,11 +5,6 @@ from core.models import Role
 
 
 @permission_required(Role.ADMIN)
-def settings_locations(request: HttpRequest, slug: str) -> HttpResponse:  # noqa: ARG001
-    return HttpResponse("TODO: locations settings")
-
-
-@permission_required(Role.ADMIN)
 def settings_members(request: HttpRequest, slug: str) -> HttpResponse:  # noqa: ARG001
     return HttpResponse("TODO: members settings")
 

--- a/templates/_partials/settings_rail.html
+++ b/templates/_partials/settings_rail.html
@@ -1,6 +1,6 @@
 {% load i18n %}<nav aria-label="{% trans 'Settings' %}">
 <ul>
-<li><a href="{% url 'core:settings_locations' organization.slug %}"{% if request.resolver_match.url_name == 'settings_locations' or request.resolver_match.url_name == 'settings_locations_create' or request.resolver_match.url_name == 'settings_locations_edit' or request.resolver_match.url_name == 'settings_locations_deactivate' or request.resolver_match.url_name == 'settings_locations_reactivate' %} aria-current="page"{% endif %}>{% trans "Locations" %}</a></li>
+<li><a href="{% url 'core:settings_locations' organization.slug %}"{% if 'settings_locations' in request.resolver_match.url_name %} aria-current="page"{% endif %}>{% trans "Locations" %}</a></li>
 <li><a href="{% url 'core:settings_members' organization.slug %}"{% if request.resolver_match.url_name == 'settings_members' %} aria-current="page"{% endif %}>{% trans "Members" %}</a></li>
 <li><a href="{% url 'core:settings_invitations' organization.slug %}"{% if request.resolver_match.url_name == 'settings_invitations' %} aria-current="page"{% endif %}>{% trans "Invitations" %}</a></li>
 <li><a href="{% url 'core:settings_organization' organization.slug %}"{% if request.resolver_match.url_name == 'settings_organization' %} aria-current="page"{% endif %}>{% trans "Organization" %}</a></li>

--- a/templates/_partials/settings_rail.html
+++ b/templates/_partials/settings_rail.html
@@ -1,0 +1,8 @@
+{% load i18n %}<nav aria-label="{% trans 'Settings' %}">
+<ul>
+<li><a href="{% url 'core:settings_locations' organization.slug %}"{% if request.resolver_match.url_name == 'settings_locations' or request.resolver_match.url_name == 'settings_locations_create' or request.resolver_match.url_name == 'settings_locations_edit' or request.resolver_match.url_name == 'settings_locations_deactivate' or request.resolver_match.url_name == 'settings_locations_reactivate' %} aria-current="page"{% endif %}>{% trans "Locations" %}</a></li>
+<li><a href="{% url 'core:settings_members' organization.slug %}"{% if request.resolver_match.url_name == 'settings_members' %} aria-current="page"{% endif %}>{% trans "Members" %}</a></li>
+<li><a href="{% url 'core:settings_invitations' organization.slug %}"{% if request.resolver_match.url_name == 'settings_invitations' %} aria-current="page"{% endif %}>{% trans "Invitations" %}</a></li>
+<li><a href="{% url 'core:settings_organization' organization.slug %}"{% if request.resolver_match.url_name == 'settings_organization' %} aria-current="page"{% endif %}>{% trans "Organization" %}</a></li>
+</ul>
+</nav>

--- a/templates/locations/_row.html
+++ b/templates/locations/_row.html
@@ -1,0 +1,20 @@
+{% load i18n %}<tr id="location-row-{{ location.pk }}">
+  <td>{{ location.name }}</td>
+  <td><code>{{ location.slug }}</code></td>
+  <td>{{ location.city }}</td>
+  <td>{% if location.is_active %}{% trans "Yes" %}{% else %}{% trans "No" %}{% endif %}</td>
+  <td>
+    <a href="{% url 'core:settings_locations_edit' organization.slug location.pk %}">{% trans "Edit" %}</a>
+    {% if location.is_active %}
+      <form method="post" action="{% url 'core:settings_locations_deactivate' organization.slug location.pk %}" hx-post="{% url 'core:settings_locations_deactivate' organization.slug location.pk %}" hx-target="#location-row-{{ location.pk }}" hx-swap="outerHTML" style="display:inline">
+        {% csrf_token %}
+        <button type="submit" class="secondary">{% trans "Deactivate" %}</button>
+      </form>
+    {% else %}
+      <form method="post" action="{% url 'core:settings_locations_reactivate' organization.slug location.pk %}" hx-post="{% url 'core:settings_locations_reactivate' organization.slug location.pk %}" hx-target="#location-row-{{ location.pk }}" hx-swap="outerHTML" style="display:inline">
+        {% csrf_token %}
+        <button type="submit">{% trans "Reactivate" %}</button>
+      </form>
+    {% endif %}
+  </td>
+</tr>

--- a/templates/locations/create.html
+++ b/templates/locations/create.html
@@ -1,0 +1,24 @@
+{% extends "base_org.html" %}
+{% load i18n forms %}
+
+{% block title %}{% trans "New location" %}{% endblock %}
+
+{% block rail %}{% include "_partials/settings_rail.html" %}{% endblock %}
+
+{% block main %}
+  <h1>{% trans "New location" %}</h1>
+  <form method="post" novalidate>
+    {% csrf_token %}
+    {% include "forms/_errors.html" %}
+    {% field form.name %}
+    {% field form.slug %}
+    {% field form.street %}
+    {% field form.postal_code %}
+    {% field form.city %}
+    {% field form.phone %}
+    {% trans "Create" as primary_label %}
+    {% trans "Cancel" as secondary_label %}
+    {% url 'core:settings_locations' organization.slug as cancel_url %}
+    {% submit primary_label secondary_label cancel_url %}
+  </form>
+{% endblock %}

--- a/templates/locations/edit.html
+++ b/templates/locations/edit.html
@@ -1,0 +1,27 @@
+{% extends "base_org.html" %}
+{% load i18n forms %}
+
+{% block title %}{% trans "Edit location" %}{% endblock %}
+
+{% block rail %}{% include "_partials/settings_rail.html" %}{% endblock %}
+
+{% block main %}
+  <h1>{% trans "Edit location" %}</h1>
+  <p>
+    <strong>{% trans "URL" %}:</strong> <code>{{ location.slug }}</code>
+    <small>{% trans "URL cannot be changed once set." %}</small>
+  </p>
+  <form method="post" novalidate>
+    {% csrf_token %}
+    {% include "forms/_errors.html" %}
+    {% field form.name %}
+    {% field form.street %}
+    {% field form.postal_code %}
+    {% field form.city %}
+    {% field form.phone %}
+    {% trans "Save" as primary_label %}
+    {% trans "Cancel" as secondary_label %}
+    {% url 'core:settings_locations' organization.slug as cancel_url %}
+    {% submit primary_label secondary_label cancel_url %}
+  </form>
+{% endblock %}

--- a/templates/locations/list.html
+++ b/templates/locations/list.html
@@ -1,0 +1,32 @@
+{% extends "base_org.html" %}
+{% load i18n %}
+
+{% block title %}{% trans "Locations" %}{% endblock %}
+
+{% block rail %}{% include "_partials/settings_rail.html" %}{% endblock %}
+
+{% block main %}
+  <header>
+    <h1>{% trans "Locations" %}</h1>
+    <a href="{% url 'core:settings_locations_create' organization.slug %}" role="button">{% trans "New location" %}</a>
+  </header>
+
+  <table>
+    <thead>
+      <tr>
+        <th>{% trans "Name" %}</th>
+        <th>{% trans "URL" %}</th>
+        <th>{% trans "City" %}</th>
+        <th>{% trans "Active" %}</th>
+        <th>{% trans "Actions" %}</th>
+      </tr>
+    </thead>
+    <tbody>
+      {% for location in locations %}
+        {% include "locations/_row.html" %}
+      {% empty %}
+        <tr><td colspan="5">{% trans "No locations yet." %}</td></tr>
+      {% endfor %}
+    </tbody>
+  </table>
+{% endblock %}

--- a/tests/test_views_locations.py
+++ b/tests/test_views_locations.py
@@ -1,0 +1,355 @@
+import pytest
+from django.test import Client
+
+from core.models import Location, LocationMembership, Organization, Role
+from tests.factories import (
+    LocationFactory,
+    LocationMembershipFactory,
+    OrganizationFactory,
+    OrganizationMembershipFactory,
+    UserFactory,
+)
+
+
+def _admin_client(
+    org: Organization | None = None,
+) -> tuple[Client, Organization]:
+    membership = OrganizationMembershipFactory(
+        role=Role.ADMIN,
+        organization=org or OrganizationFactory(),
+    )
+    client = Client()
+    client.force_login(membership.user)
+    return client, membership.organization
+
+
+def _routes(slug: str, pk: int = 1) -> dict[str, str]:
+    base = f"/o/{slug}/settings/locations"
+    return {
+        "list": f"{base}/",
+        "create": f"{base}/new/",
+        "edit": f"{base}/{pk}/edit/",
+        "deactivate": f"{base}/{pk}/deactivate/",
+        "reactivate": f"{base}/{pk}/reactivate/",
+    }
+
+
+# ---- anonymous --------------------------------------------------------------
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    "key", ["list", "create", "edit", "deactivate", "reactivate"]
+)
+def test_anonymous_redirects_or_404(key: str) -> None:
+    org = OrganizationFactory()
+    location = LocationFactory(organization=org)
+    routes = _routes(org.slug, location.pk)
+    method = "post" if key in {"deactivate", "reactivate"} else "get"
+    response = getattr(Client(), method)(routes[key])
+    # TenantMiddleware raises 404 for unauthenticated access to /o/<slug>/.
+    assert response.status_code == 404
+
+
+# ---- operator forbidden -----------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_operator_forbidden_on_all_routes() -> None:
+    membership = OrganizationMembershipFactory(role=Role.OPERATOR)
+    org = membership.organization
+    location = LocationFactory(organization=org)
+    client = Client()
+    client.force_login(membership.user)
+
+    routes = _routes(org.slug, location.pk)
+    assert client.get(routes["list"]).status_code == 403
+    assert client.get(routes["create"]).status_code == 403
+    assert client.post(routes["create"], {}).status_code == 403
+    assert client.get(routes["edit"]).status_code == 403
+    assert client.post(routes["edit"], {}).status_code == 403
+    assert client.post(routes["deactivate"]).status_code == 403
+    assert client.post(routes["reactivate"]).status_code == 403
+
+
+# ---- list -------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_admin_list_shows_active_and_inactive() -> None:
+    client, org = _admin_client()
+    LocationFactory(organization=org, name="Alpha", is_active=True)
+    LocationFactory(organization=org, name="Beta", is_active=False)
+
+    response = client.get(_routes(org.slug)["list"])
+
+    assert response.status_code == 200
+    body = response.content.decode()
+    assert "Alpha" in body
+    assert "Beta" in body
+    # Active sorts first (order_by -is_active, name).
+    assert body.index("Alpha") < body.index("Beta")
+
+
+@pytest.mark.django_db
+def test_admin_list_does_not_leak_other_orgs() -> None:
+    client, org = _admin_client()
+    other = OrganizationFactory()
+    LocationFactory(organization=other, name="OtherOrgLoc")
+
+    response = client.get(_routes(org.slug)["list"])
+
+    assert response.status_code == 200
+    assert "OtherOrgLoc" not in response.content.decode()
+
+
+# ---- create -----------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_admin_create_persists_with_request_org() -> None:
+    client, org = _admin_client()
+    response = client.post(
+        _routes(org.slug)["create"],
+        {
+            "name": "Main",
+            "slug": "main",
+            "street": "Rue 1",
+            "postal_code": "1000",
+            "city": "Brussels",
+            "phone": "",
+        },
+    )
+    assert response.status_code == 302
+    assert response["Location"] == _routes(org.slug)["list"]
+    loc = Location.tenant_objects.for_organization(org).get(slug="main")
+    assert loc.name == "Main"
+    assert loc.is_active is True
+
+
+@pytest.mark.django_db
+def test_admin_create_duplicate_slug_same_org_renders_form_error() -> None:
+    client, org = _admin_client()
+    LocationFactory(organization=org, slug="dup")
+
+    response = client.post(
+        _routes(org.slug)["create"],
+        {
+            "name": "Dup",
+            "slug": "dup",
+            "street": "Rue",
+            "postal_code": "1000",
+            "city": "Brussels",
+            "phone": "",
+        },
+    )
+    assert response.status_code == 200
+    assert "already exists" in response.content.decode()
+    assert (
+        Location.tenant_objects.for_organization(org).filter(slug="dup").count()
+        == 1
+    )
+
+
+@pytest.mark.django_db
+def test_create_same_slug_different_org_succeeds() -> None:
+    client, org = _admin_client()
+    other = OrganizationFactory()
+    LocationFactory(organization=other, slug="shared")
+
+    response = client.post(
+        _routes(org.slug)["create"],
+        {
+            "name": "Shared",
+            "slug": "shared",
+            "street": "Rue",
+            "postal_code": "1000",
+            "city": "Brussels",
+            "phone": "",
+        },
+    )
+    assert response.status_code == 302
+    assert (
+        Location.tenant_objects.for_organization(org)
+        .filter(slug="shared")
+        .exists()
+    )
+
+
+# ---- edit -------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_admin_edit_get_omits_slug_field() -> None:
+    client, org = _admin_client()
+    location = LocationFactory(organization=org, slug="immutable")
+
+    response = client.get(_routes(org.slug, location.pk)["edit"])
+
+    assert response.status_code == 200
+    body = response.content.decode()
+    assert 'name="slug"' not in body
+    # Slug still shown read-only.
+    assert "immutable" in body
+
+
+@pytest.mark.django_db
+def test_admin_edit_post_updates_fields() -> None:
+    client, org = _admin_client()
+    location = LocationFactory(organization=org, name="Old")
+
+    response = client.post(
+        _routes(org.slug, location.pk)["edit"],
+        {
+            "name": "New",
+            "street": "Rue 2",
+            "postal_code": "2000",
+            "city": "Antwerp",
+            "phone": "+3201",
+        },
+    )
+    assert response.status_code == 302
+    location.refresh_from_db()
+    assert location.name == "New"
+    assert location.city == "Antwerp"
+    # Slug unchanged because field was dropped from the form.
+    assert (
+        location.slug
+        == LocationFactory._meta.model.objects.get(pk=location.pk).slug
+    )
+
+
+# ---- deactivate / reactivate ------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_admin_deactivate_htmx_returns_row_partial() -> None:
+    client, org = _admin_client()
+    location = LocationFactory(organization=org, is_active=True)
+
+    response = client.post(
+        _routes(org.slug, location.pk)["deactivate"],
+        HTTP_HX_REQUEST="true",
+    )
+
+    assert response.status_code == 200
+    body = response.content.decode()
+    assert f'id="location-row-{location.pk}"' in body
+    assert "Reactivate" in body
+    location.refresh_from_db()
+    assert location.is_active is False
+
+
+@pytest.mark.django_db
+def test_deactivate_preserves_location_memberships() -> None:
+    client, org = _admin_client()
+    location = LocationFactory(organization=org, is_active=True)
+    user = UserFactory()
+    LocationMembershipFactory(user=user, location=location)
+
+    response = client.post(
+        _routes(org.slug, location.pk)["deactivate"],
+        HTTP_HX_REQUEST="true",
+    )
+
+    assert response.status_code == 200
+    assert LocationMembership.objects.filter(
+        user=user, location=location
+    ).exists()
+
+
+@pytest.mark.django_db
+def test_admin_deactivate_non_htmx_redirects_to_list() -> None:
+    client, org = _admin_client()
+    location = LocationFactory(organization=org, is_active=True)
+
+    response = client.post(_routes(org.slug, location.pk)["deactivate"])
+
+    assert response.status_code == 302
+    assert response["Location"] == _routes(org.slug)["list"]
+    location.refresh_from_db()
+    assert location.is_active is False
+
+
+@pytest.mark.django_db
+def test_admin_reactivate_htmx_returns_row_partial() -> None:
+    client, org = _admin_client()
+    location = LocationFactory(organization=org, is_active=False)
+
+    response = client.post(
+        _routes(org.slug, location.pk)["reactivate"],
+        HTTP_HX_REQUEST="true",
+    )
+
+    assert response.status_code == 200
+    body = response.content.decode()
+    assert f'id="location-row-{location.pk}"' in body
+    assert "Deactivate" in body
+    location.refresh_from_db()
+    assert location.is_active is True
+
+
+# ---- method guards ----------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_get_on_deactivate_or_reactivate_returns_405() -> None:
+    client, org = _admin_client()
+    location = LocationFactory(organization=org)
+    routes = _routes(org.slug, location.pk)
+    assert client.get(routes["deactivate"]).status_code == 405
+    assert client.get(routes["reactivate"]).status_code == 405
+
+
+# ---- cross-org tenant scoping ----------------------------------------------
+
+
+@pytest.mark.django_db
+def test_cross_org_edit_returns_404() -> None:
+    client, org = _admin_client()
+    other_org = OrganizationFactory()
+    other_loc = LocationFactory(organization=other_org)
+
+    response = client.get(_routes(org.slug, other_loc.pk)["edit"])
+    assert response.status_code == 404
+
+
+@pytest.mark.django_db
+def test_cross_org_deactivate_returns_404() -> None:
+    client, org = _admin_client()
+    other_org = OrganizationFactory()
+    other_loc = LocationFactory(organization=other_org, is_active=True)
+
+    response = client.post(_routes(org.slug, other_loc.pk)["deactivate"])
+    assert response.status_code == 404
+    other_loc.refresh_from_db()
+    assert other_loc.is_active is True
+
+
+@pytest.mark.django_db
+def test_cross_org_reactivate_returns_404() -> None:
+    client, org = _admin_client()
+    other_org = OrganizationFactory()
+    other_loc = LocationFactory(organization=other_org, is_active=False)
+
+    response = client.post(_routes(org.slug, other_loc.pk)["reactivate"])
+    assert response.status_code == 404
+    other_loc.refresh_from_db()
+    assert other_loc.is_active is False
+
+
+# ---- superuser sanity -------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_superuser_can_access_list() -> None:
+    superuser = UserFactory(superuser=True)
+    org = OrganizationFactory()
+    LocationFactory(organization=org, name="ListedForSuperuser")
+
+    client = Client()
+    client.force_login(superuser)
+    response = client.get(_routes(org.slug)["list"])
+
+    assert response.status_code == 200
+    assert "ListedForSuperuser" in response.content.decode()


### PR DESCRIPTION
## Summary
- Admin pages at `/o/<slug>/settings/locations/` for list / create / edit / deactivate / reactivate. Routes are ADMIN-only; OPERATOR and cross-org get 403/404 respectively. All view querysets go through `Location.tenant_objects.for_request(request)`.
- HTMX row-partial swap for (de)activation; full-page render for everything else and for non-HTMX POSTs (graceful no-JS fallback). Real `<form>` elements for CSRF.
- New `core/services/location.py` (idempotent `deactivate_location` / `reactivate_location` with `select_for_update` lock), `core/forms/location.py` (`LocationForm` with `editing` flag that drops slug post-creation and an org-scoped slug uniqueness check), and a shared `templates/_partials/settings_rail.html`.

## Deviations from issue text
- **`{% include %}` partials instead of `django-template-partials`.** The library isn't installed and isn't used anywhere else; a sibling `_row.html` matches the existing `templates/_partials/` convention and yields the same swap UX.
- **Cross-org access returns 404, not 403.** Object lookups go through `get_object_or_404(Location.tenant_objects.for_request(request), pk=...)`, which matches the convention from `tests/test_views_dashboard.py`. 403 is reserved for OPERATOR role mismatch.

## Test plan
- [x] `pytest tests/test_views_locations.py` — 22 cases green (roles, tenant scoping, HTMX row swap, `LocationMembership` preservation, method guards, superuser sanity)
- [x] Full suite — 419 passed, 1 skipped, no regressions
- [x] `python manage.py makemigrations --check core` — no schema change
- [x] `python scripts/tenant_lint.py` — clean
- [x] `ruff check` and `pyright` — clean
- [x] Manual Playwright walkthrough: ADMIN create / edit / HTMX (de)activate verified in-place row swap, OPERATOR → 403, cross-org pk → 404, anonymous → 404

🤖 Generated with [Claude Code](https://claude.com/claude-code)