### PR TITLE
feat(2c): organization settings page at /o/<slug>/settings/organization/

### DIFF
--- a/core/forms/organization.py
+++ b/core/forms/organization.py
@@ -1,0 +1,16 @@
+from typing import ClassVar
+
+from django import forms
+
+from core.models import Organization
+
+
+class OrganizationSettingsForm(forms.ModelForm):
+    class Meta:
+        model = Organization
+        fields: ClassVar[list[str]] = [
+            "name",
+            "country",
+            "vat_number",
+            "default_language",
+        ]

--- a/core/urls.py
+++ b/core/urls.py
@@ -16,7 +16,7 @@ from .views.auth import (
 )
 from .views.dashboard import dashboard
 from .views.design import design_kitchen_sink
-from .views.settings import settings_organization
+from .views.organization import settings_view as settings_organization
 
 app_name = "core"
 

--- a/core/views/organization.py
+++ b/core/views/organization.py
@@ -1,0 +1,23 @@
+from django.http import HttpRequest, HttpResponse
+from django.shortcuts import redirect, render
+
+from core.decorators import permission_required
+from core.forms.organization import OrganizationSettingsForm
+from core.models import Role
+
+
+@permission_required(Role.ADMIN)
+def settings_view(request: HttpRequest, slug: str) -> HttpResponse:
+    organization = request.organization  # type: ignore[attr-defined]
+    if request.method == "POST":
+        form = OrganizationSettingsForm(request.POST, instance=organization)
+        if form.is_valid():
+            form.save()
+            return redirect("core:settings_organization", slug=slug)
+    else:
+        form = OrganizationSettingsForm(instance=organization)
+    return render(
+        request,
+        "organization/settings.html",
+        {"organization": organization, "form": form},
+    )

--- a/core/views/settings.py
+++ b/core/views/settings.py
@@ -1,9 +1,0 @@
-from django.http import HttpRequest, HttpResponse
-
-from core.decorators import permission_required
-from core.models import Role
-
-
-@permission_required(Role.ADMIN)
-def settings_organization(request: HttpRequest, slug: str) -> HttpResponse:  # noqa: ARG001
-    return HttpResponse("TODO: organization settings")

--- a/templates/organization/settings.html
+++ b/templates/organization/settings.html
@@ -1,0 +1,26 @@
+{% extends "base_org.html" %}
+{% load i18n forms %}
+
+{% block title %}{% trans "Organization settings" %}{% endblock %}
+
+{% block rail %}{% include "_partials/settings_rail.html" %}{% endblock %}
+
+{% block main %}
+  <h1>{% trans "Organization settings" %}</h1>
+  <p>
+    <strong>{% trans "URL" %}:</strong> <code>{{ organization.slug }}</code>
+    <small>{% trans "URL cannot be changed once set." %}</small>
+  </p>
+  <form method="post" novalidate>
+    {% csrf_token %}
+    {% include "forms/_errors.html" %}
+    {% field form.name %}
+    {% field form.country %}
+    {% field form.vat_number %}
+    {% field form.default_language %}
+    {% trans "Save" as primary_label %}
+    {% trans "Cancel" as secondary_label %}
+    {% url 'core:settings_organization' organization.slug as cancel_url %}
+    {% submit primary_label secondary_label cancel_url %}
+  </form>
+{% endblock %}

--- a/tests/test_views_organization.py
+++ b/tests/test_views_organization.py
@@ -1,0 +1,164 @@
+import pytest
+from django.test import Client
+
+from core.models import Organization, Role
+from core.services.invitation import create_invitation
+from tests.factories import OrganizationFactory, OrganizationMembershipFactory
+
+
+def _url(slug: str) -> str:
+    return f"/o/{slug}/settings/organization/"
+
+
+def _admin_client(
+    org: Organization | None = None,
+) -> tuple[Client, Organization]:
+    membership = OrganizationMembershipFactory(
+        role=Role.ADMIN,
+        organization=org or OrganizationFactory(),
+    )
+    client = Client()
+    client.force_login(membership.user)
+    return client, membership.organization
+
+
+def _post_data(org: Organization, **overrides: str) -> dict[str, str]:
+    data = {
+        "name": org.name,
+        "country": str(org.country),
+        "vat_number": org.vat_number,
+        "default_language": org.default_language,
+    }
+    data.update(overrides)
+    return data
+
+
+# ---- anonymous --------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_anonymous_returns_404() -> None:
+    org = OrganizationFactory()
+    response = Client().get(_url(org.slug))
+    assert response.status_code == 404
+
+
+# ---- operator forbidden -----------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_operator_forbidden() -> None:
+    membership = OrganizationMembershipFactory(role=Role.OPERATOR)
+    client = Client()
+    client.force_login(membership.user)
+    url = _url(membership.organization.slug)
+
+    assert client.get(url).status_code == 403
+    assert (
+        client.post(url, _post_data(membership.organization)).status_code == 403
+    )
+
+
+# ---- admin GET --------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_admin_get_renders_form_without_slug_field() -> None:
+    client, org = _admin_client()
+
+    response = client.get(_url(org.slug))
+
+    assert response.status_code == 200
+    body = response.content.decode()
+    assert org.name in body
+    # Slug shown read-only.
+    assert f"<code>{org.slug}</code>" in body
+    # No editable slug input.
+    assert 'name="slug"' not in body
+    # Editable fields are present.
+    assert 'name="name"' in body
+    assert 'name="country"' in body
+    assert 'name="vat_number"' in body
+    assert 'name="default_language"' in body
+
+
+# ---- admin POST -------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_admin_post_updates_fields_and_redirects() -> None:
+    client, org = _admin_client()
+
+    response = client.post(
+        _url(org.slug),
+        _post_data(
+            org,
+            name="Renamed Org",
+            default_language="fr-BE",
+        ),
+    )
+
+    assert response.status_code == 302
+    assert response["Location"] == _url(org.slug)
+    org.refresh_from_db()
+    assert org.name == "Renamed Org"
+    assert org.default_language == "fr-BE"
+
+
+@pytest.mark.django_db
+def test_admin_post_invalid_vat_returns_field_error() -> None:
+    client, org = _admin_client()
+    original_vat = org.vat_number
+
+    response = client.post(
+        _url(org.slug),
+        _post_data(org, vat_number="BE000"),
+    )
+
+    assert response.status_code == 200
+    form = response.context["form"]
+    assert "vat_number" in form.errors
+    org.refresh_from_db()
+    assert org.vat_number == original_vat
+
+
+@pytest.mark.django_db
+def test_admin_cannot_edit_other_org() -> None:
+    client, _ = _admin_client()
+    other = OrganizationFactory()
+
+    assert client.get(_url(other.slug)).status_code == 404
+    assert client.post(_url(other.slug), _post_data(other)).status_code == 404
+
+
+# ---- default_language propagates to subsequent emails -----------------------
+
+
+@pytest.mark.django_db
+def test_default_language_change_reflected_in_invitation_email(
+    mailoutbox: list,
+    django_capture_on_commit_callbacks,  # noqa: ANN001
+) -> None:
+    client, org = _admin_client()
+
+    response = client.post(
+        _url(org.slug),
+        _post_data(org, default_language="fr-BE"),
+    )
+    assert response.status_code == 302
+
+    org.refresh_from_db()
+    membership = OrganizationMembershipFactory(
+        role=Role.ADMIN, organization=org
+    )
+    with django_capture_on_commit_callbacks(execute=True):
+        create_invitation(
+            organization=org,
+            email="newcomer@example.be",
+            role=Role.ADMIN,
+            created_by=membership.user,
+        )
+
+    msg = mailoutbox[-1]
+    html = str(msg.alternatives[0][0])
+    assert 'lang="fr-be"' in html.lower()


### PR DESCRIPTION
## Summary
- ADMIN-only form for `name`, `country`, `vat_number`, `default_language`; `slug` stays immutable. Closes #82.
- Replaces the TODO stub view with `core/views/organization.py:settings_view` and a new `OrganizationSettingsForm` (ModelForm) that reuses `Organization.clean()` for VAT validation.
- Adds `templates/organization/settings.html` and `tests/test_views_organization.py`. Settings rail already had the Organization link wired.

## Test plan
- [x] `uv run pytest tests/test_views_organization.py` (7 passed)
- [x] `uv run pytest` full suite (480 passed, 1 skipped, no regressions)
- [x] `uv run ruff check` and `uv run pyright` clean on changed files
- [x] Manual via Playwright as ADMIN: rename + change `default_language` -> persisted, redirected, topbar updates
- [x] Manual: invalid VAT (`BE000`) -> inline `aria-invalid` + helper "Invalid BE VAT number.", DB unchanged
- [x] Manual via curl: OPERATOR -> 403 on GET and POST
- [x] Verified `default_language` propagates to subsequent invitation emails (rendered `lang="fr-be"`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)