### PR TITLE
feat(2c): profile self-service at /me/ (profile + change password)

### DIFF
--- a/core/forms/profile.py
+++ b/core/forms/profile.py
@@ -1,0 +1,61 @@
+from collections.abc import Mapping
+from typing import Any
+
+from django import forms
+from django.conf import settings
+from django.contrib.auth.password_validation import validate_password
+from django.core.exceptions import ValidationError
+from django.utils.translation import gettext_lazy as _
+
+from core.models import User
+
+
+class ProfileForm(forms.Form):
+    first_name = forms.CharField(
+        label=_("First name"), max_length=150, required=False
+    )
+    last_name = forms.CharField(
+        label=_("Last name"), max_length=150, required=False
+    )
+    preferred_language = forms.ChoiceField(
+        label=_("Preferred language"),
+        choices=[("", _("Use browser/org default")), *settings.LANGUAGES],
+        required=False,
+    )
+
+
+class ChangePasswordForm(forms.Form):
+    current_password = forms.CharField(
+        label=_("Current password"),
+        widget=forms.PasswordInput(render_value=False),
+        strip=False,
+    )
+    new_password1 = forms.CharField(
+        label=_("New password"),
+        widget=forms.PasswordInput(render_value=False),
+        strip=False,
+    )
+    new_password2 = forms.CharField(
+        label=_("Confirm new password"),
+        widget=forms.PasswordInput(render_value=False),
+        strip=False,
+    )
+
+    def __init__(
+        self, data: Mapping[str, Any] | None = None, *, user: User
+    ) -> None:
+        self.user = user
+        super().__init__(data)
+
+    def clean(self) -> dict[str, Any]:
+        cleaned: dict[str, Any] = super().clean() or {}
+        p1 = cleaned.get("new_password1")
+        p2 = cleaned.get("new_password2")
+        if p1 and p2 and p1 != p2:
+            self.add_error("new_password2", _("Passwords do not match."))
+        if p1 and not self.has_error("new_password1"):
+            try:
+                validate_password(p1, user=self.user)
+            except ValidationError as e:
+                self.add_error("new_password1", e)
+        return cleaned

--- a/core/urls.py
+++ b/core/urls.py
@@ -2,7 +2,7 @@ from django.conf import settings
 from django.urls import path
 from django.urls.resolvers import URLPattern
 
-from .views import home, invitations, locations, members
+from .views import home, invitations, locations, members, profile
 from .views.auth import (
     login,
     logout,
@@ -48,6 +48,17 @@ urlpatterns: list[URLPattern] = [
         name="password_reset_confirm",
     ),
     path(route="orgs/", view=org_picker, name="org_picker"),
+    path(route="me/", view=profile.me, name="profile"),
+    path(
+        route="me/profile/",
+        view=profile.update_profile_view,
+        name="profile_update",
+    ),
+    path(
+        route="me/password/",
+        view=profile.change_password_view,
+        name="profile_password",
+    ),
     path(route="o/<slug:slug>/", view=dashboard, name="org_dashboard"),
     path(
         route="o/<slug:slug>/settings/locations/",

--- a/core/views/profile.py
+++ b/core/views/profile.py
@@ -1,0 +1,100 @@
+from typing import cast
+
+from django.contrib import messages
+from django.contrib.auth.decorators import login_required
+from django.core.exceptions import ValidationError as DjangoValidationError
+from django.http import HttpRequest, HttpResponse
+from django.shortcuts import redirect, render
+from django.utils.translation import gettext_lazy as _
+from django.views.decorators.http import require_POST
+
+from core.forms.profile import ChangePasswordForm, ProfileForm
+from core.models import User
+from core.services.exceptions import WeakPasswordError, WrongPasswordError
+from core.services.profile import change_password, update_profile
+
+
+def _profile_initial(user: User) -> dict[str, str]:
+    return {
+        "first_name": user.first_name,
+        "last_name": user.last_name,
+        "preferred_language": user.preferred_language,
+    }
+
+
+@login_required
+def me(request: HttpRequest) -> HttpResponse:
+    user = cast(User, request.user)
+    return render(
+        request,
+        "profile/me.html",
+        {
+            "profile_form": ProfileForm(initial=_profile_initial(user)),
+            "password_form": ChangePasswordForm(user=user),
+        },
+    )
+
+
+@require_POST
+@login_required
+def update_profile_view(request: HttpRequest) -> HttpResponse:
+    user = cast(User, request.user)
+    form = ProfileForm(request.POST)
+    if form.is_valid():
+        try:
+            update_profile(
+                user,
+                first_name=form.cleaned_data["first_name"],
+                last_name=form.cleaned_data["last_name"],
+                preferred_language=form.cleaned_data["preferred_language"],
+            )
+        except DjangoValidationError as exc:
+            for field, errors in exc.message_dict.items():
+                for message in errors:
+                    form.add_error(field, message)
+        else:
+            messages.success(request, _("Profile updated."))
+            return redirect("core:profile")
+    return render(
+        request,
+        "profile/me.html",
+        {
+            "profile_form": form,
+            "password_form": ChangePasswordForm(user=user),
+        },
+    )
+
+
+@require_POST
+@login_required
+def change_password_view(request: HttpRequest) -> HttpResponse:
+    user = cast(User, request.user)
+    form = ChangePasswordForm(request.POST, user=user)
+    if form.is_valid():
+        try:
+            change_password(
+                request,
+                current_password=form.cleaned_data["current_password"],
+                new_password=form.cleaned_data["new_password1"],
+            )
+        except WrongPasswordError:
+            form.add_error(
+                "current_password", _("Current password is incorrect.")
+            )
+        except WeakPasswordError as exc:
+            for message in exc.messages:
+                form.add_error("new_password1", message)
+        else:
+            messages.success(
+                request,
+                _("Password changed. Other sessions have been signed out."),
+            )
+            return redirect("core:profile")
+    return render(
+        request,
+        "profile/me.html",
+        {
+            "profile_form": ProfileForm(initial=_profile_initial(user)),
+            "password_form": form,
+        },
+    )

--- a/templates/_partials/user_menu.html
+++ b/templates/_partials/user_menu.html
@@ -1,4 +1,4 @@
 {% load i18n %}{% if request.user.is_authenticated %}<details class="dropdown user-menu">
 <summary>{% if request.user.first_name or request.user.last_name %}{{ request.user.first_name }} {{ request.user.last_name }}{% else %}{{ request.user.email }}{% endif %}</summary>
-<ul>{% url 'profile' as profile_url %}{% if profile_url %}<li><a href="{{ profile_url }}">{% trans "Profile" %}</a></li>{% endif %}<li><form method="post" action="{% url 'core:logout' %}">{% csrf_token %}<button type="submit" class="secondary">{% trans "Sign out" %}</button></form></li></ul>
+<ul><li><a href="{% url 'core:profile' %}">{% trans "Profile" %}</a></li><li><form method="post" action="{% url 'core:logout' %}">{% csrf_token %}<button type="submit" class="secondary">{% trans "Sign out" %}</button></form></li></ul>
 </details>{% endif %}

--- a/templates/profile/me.html
+++ b/templates/profile/me.html
@@ -1,0 +1,34 @@
+{% extends "base_picker.html" %}
+{% load i18n forms %}
+
+{% block title %}{% trans "Your profile" %}{% endblock %}
+
+{% block main %}
+  <h1>{% trans "Your profile" %}</h1>
+
+  <section>
+    <h2>{% trans "Profile details" %}</h2>
+    <form method="post" action="{% url 'core:profile_update' %}" novalidate>
+      {% csrf_token %}
+      {% include "forms/_errors.html" with form=profile_form %}
+      {% field profile_form.first_name %}
+      {% field profile_form.last_name %}
+      {% field profile_form.preferred_language %}
+      {% trans "Save" as submit_label %}
+      {% submit submit_label %}
+    </form>
+  </section>
+
+  <section>
+    <h2>{% trans "Change password" %}</h2>
+    <form method="post" action="{% url 'core:profile_password' %}" novalidate>
+      {% csrf_token %}
+      {% include "forms/_errors.html" with form=password_form %}
+      {% field password_form.current_password %}
+      {% field password_form.new_password1 %}
+      {% field password_form.new_password2 %}
+      {% trans "Change password" as submit_label %}
+      {% submit submit_label %}
+    </form>
+  </section>
+{% endblock %}

--- a/tests/test_design_partials.py
+++ b/tests/test_design_partials.py
@@ -17,11 +17,16 @@ def _stub(request: HttpRequest) -> HttpResponse:
     return HttpResponse()
 
 
-_core_patterns = ([path("logout/", _stub, name="logout")], "core")
+_core_patterns = (
+    [
+        path("logout/", _stub, name="logout"),
+        path("me/", _stub, name="profile"),
+    ],
+    "core",
+)
 
 urlpatterns = [
     path("", include(_core_patterns, namespace="core")),
-    path("profile/", _stub, name="profile"),
     path("i18n/", include("django.conf.urls.i18n")),
 ]
 
@@ -108,25 +113,13 @@ def test_user_menu_falls_back_to_email_when_name_blank() -> None:
 
 
 @pytest.mark.django_db
-def test_user_menu_omits_profile_when_url_undefined() -> None:
-    # Sign out always renders against core:logout; the project URLconf
-    # does not yet expose a `profile` URL, so that link stays dormant.
-    user = UserFactory()
-    out = _render_include(
-        "_partials/user_menu.html", request=_request(user=user)
-    )
-    assert "Profile" not in out
-    assert "Sign out" in out
-
-
-@pytest.mark.django_db
 @override_settings(ROOT_URLCONF=__name__)
-def test_user_menu_renders_profile_and_logout_when_urls_defined() -> None:
+def test_user_menu_renders_profile_and_logout() -> None:
     user = UserFactory()
     out = _render_include(
         "_partials/user_menu.html", request=_request(user=user)
     )
-    assert 'href="/profile/"' in out
+    assert 'href="/me/"' in out
     assert "Profile" in out
     assert 'action="/logout/"' in out
     assert 'method="post"' in out

--- a/tests/test_views_profile.py
+++ b/tests/test_views_profile.py
@@ -1,0 +1,279 @@
+import pytest
+from django.contrib.auth import (
+    BACKEND_SESSION_KEY,
+    HASH_SESSION_KEY,
+    SESSION_KEY,
+)
+from django.contrib.sessions.backends.db import SessionStore
+from django.contrib.sessions.models import Session
+from django.test import Client
+
+from core.models import User
+from tests.factories import UserFactory
+
+ME_URL = "/me/"
+PROFILE_URL = "/me/profile/"
+PASSWORD_URL = "/me/password/"
+
+CURRENT_PASSWORD = "password"  # UserFactory default
+NEW_PASSWORD = "Hunter2-Strongish!"
+
+
+def _create_db_session_for(user: User) -> Session:
+    store = SessionStore()
+    store[SESSION_KEY] = str(user.pk)
+    store[BACKEND_SESSION_KEY] = "django.contrib.auth.backends.ModelBackend"
+    store[HASH_SESSION_KEY] = user.get_session_auth_hash()
+    store.create()
+    return Session.objects.get(session_key=store.session_key)
+
+
+# ---- anonymous --------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_anonymous_redirects_to_login() -> None:
+    response = Client().get(ME_URL)
+    assert response.status_code == 302
+    assert response["Location"] == f"/login/?next={ME_URL}"
+
+
+# ---- GET /me/ ---------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_authenticated_get_renders_both_forms() -> None:
+    user = UserFactory()
+    client = Client()
+    client.force_login(user)
+
+    response = client.get(ME_URL)
+
+    assert response.status_code == 200
+    body = response.content.decode()
+    assert f'action="{PROFILE_URL}"' in body
+    assert f'action="{PASSWORD_URL}"' in body
+    assert 'name="first_name"' in body
+    assert 'name="preferred_language"' in body
+    assert 'name="current_password"' in body
+    assert 'name="new_password1"' in body
+    assert 'name="new_password2"' in body
+
+
+@pytest.mark.django_db
+def test_me_works_without_org_context() -> None:
+    # Newly invited user with no memberships should still be able to reach /me/.
+    user = UserFactory()
+    client = Client()
+    client.force_login(user)
+
+    response = client.get(ME_URL)
+
+    assert response.status_code == 200
+
+
+# ---- POST /me/profile/ ------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_post_profile_updates_fields_and_redirects() -> None:
+    user = UserFactory(first_name="", last_name="", preferred_language="")
+    client = Client()
+    client.force_login(user)
+
+    response = client.post(
+        PROFILE_URL,
+        {
+            "first_name": "Ada",
+            "last_name": "Lovelace",
+            "preferred_language": "fr-BE",
+        },
+    )
+
+    assert response.status_code == 302
+    assert response["Location"] == ME_URL
+    user.refresh_from_db()
+    assert user.first_name == "Ada"
+    assert user.last_name == "Lovelace"
+    assert user.preferred_language == "fr-BE"
+
+
+@pytest.mark.django_db
+def test_post_profile_blank_language_clears_field() -> None:
+    user = UserFactory(preferred_language="fr-BE")
+    client = Client()
+    client.force_login(user)
+
+    response = client.post(
+        PROFILE_URL,
+        {
+            "first_name": "A",
+            "last_name": "B",
+            "preferred_language": "",
+        },
+    )
+
+    assert response.status_code == 302
+    user.refresh_from_db()
+    assert user.preferred_language == ""
+
+
+@pytest.mark.django_db
+def test_post_profile_unknown_language_renders_error() -> None:
+    user = UserFactory(preferred_language="en-US")
+    client = Client()
+    client.force_login(user)
+
+    response = client.post(
+        PROFILE_URL,
+        {
+            "first_name": "A",
+            "last_name": "B",
+            "preferred_language": "xx-XX",
+        },
+    )
+
+    assert response.status_code == 200
+    form = response.context["profile_form"]
+    assert "preferred_language" in form.errors
+    user.refresh_from_db()
+    assert user.preferred_language == "en-US"
+
+
+@pytest.mark.django_db
+def test_get_only_routes_reject_get() -> None:
+    user = UserFactory()
+    client = Client()
+    client.force_login(user)
+
+    assert client.get(PROFILE_URL).status_code == 405
+    assert client.get(PASSWORD_URL).status_code == 405
+
+
+# ---- POST /me/password/ -----------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_post_password_wrong_current_renders_error() -> None:
+    user = UserFactory()
+    original_hash = user.password
+    client = Client()
+    client.force_login(user)
+
+    response = client.post(
+        PASSWORD_URL,
+        {
+            "current_password": "not-the-password",
+            "new_password1": NEW_PASSWORD,
+            "new_password2": NEW_PASSWORD,
+        },
+    )
+
+    assert response.status_code == 200
+    form = response.context["password_form"]
+    assert "current_password" in form.errors
+    user.refresh_from_db()
+    assert user.password == original_hash
+
+
+@pytest.mark.django_db
+def test_post_password_mismatch_renders_error() -> None:
+    user = UserFactory()
+    original_hash = user.password
+    client = Client()
+    client.force_login(user)
+
+    response = client.post(
+        PASSWORD_URL,
+        {
+            "current_password": CURRENT_PASSWORD,
+            "new_password1": NEW_PASSWORD,
+            "new_password2": NEW_PASSWORD + "x",
+        },
+    )
+
+    assert response.status_code == 200
+    form = response.context["password_form"]
+    assert "new_password2" in form.errors
+    user.refresh_from_db()
+    assert user.password == original_hash
+
+
+@pytest.mark.django_db
+def test_post_password_weak_renders_error() -> None:
+    user = UserFactory()
+    original_hash = user.password
+    client = Client()
+    client.force_login(user)
+
+    response = client.post(
+        PASSWORD_URL,
+        {
+            "current_password": CURRENT_PASSWORD,
+            "new_password1": "123",
+            "new_password2": "123",
+        },
+    )
+
+    assert response.status_code == 200
+    form = response.context["password_form"]
+    assert "new_password1" in form.errors
+    user.refresh_from_db()
+    assert user.password == original_hash
+
+
+@pytest.mark.django_db
+def test_post_password_success_keeps_current_session_and_invalidates_others() -> (
+    None
+):
+    user = UserFactory()
+    other_session = _create_db_session_for(user)
+    client = Client()
+    client.force_login(user)
+
+    response = client.post(
+        PASSWORD_URL,
+        {
+            "current_password": CURRENT_PASSWORD,
+            "new_password1": NEW_PASSWORD,
+            "new_password2": NEW_PASSWORD,
+        },
+    )
+
+    assert response.status_code == 302
+    assert response["Location"] == ME_URL
+
+    # Current session still authenticated: a follow-up authenticated GET works.
+    follow_up = client.get(ME_URL)
+    assert follow_up.status_code == 200
+
+    # The other session for the same user has been deleted.
+    assert not Session.objects.filter(
+        session_key=other_session.session_key
+    ).exists()
+
+    user.refresh_from_db()
+    assert user.check_password(NEW_PASSWORD)
+
+
+@pytest.mark.django_db
+def test_post_password_success_leaves_other_users_sessions_alone() -> None:
+    user = UserFactory()
+    other_user = UserFactory()
+    other_user_session = _create_db_session_for(other_user)
+    client = Client()
+    client.force_login(user)
+
+    response = client.post(
+        PASSWORD_URL,
+        {
+            "current_password": CURRENT_PASSWORD,
+            "new_password1": NEW_PASSWORD,
+            "new_password2": NEW_PASSWORD,
+        },
+    )
+
+    assert response.status_code == 302
+    assert Session.objects.filter(
+        session_key=other_user_session.session_key
+    ).exists()

--- a/tests/test_views_profile.py
+++ b/tests/test_views_profile.py
@@ -223,9 +223,7 @@ def test_post_password_weak_renders_error() -> None:
 
 
 @pytest.mark.django_db
-def test_post_password_success_keeps_current_session_and_invalidates_others() -> (
-    None
-):
+def test_post_password_success_keeps_session_kills_others() -> None:
     user = UserFactory()
     other_session = _create_db_session_for(user)
     client = Client()


### PR DESCRIPTION
Closes #83.

## Summary
- `/me/` renders `ProfileForm` (first_name / last_name / preferred_language) and `ChangePasswordForm` together. Top-level route, **not** tenant-scoped, so it works for users without a current org context (e.g. right after invite-accept).
- `POST /me/profile/` -> `services.profile.update_profile` -> redirect to `/me/` + flash "Profile updated."
- `POST /me/password/` -> `services.profile.change_password` -> redirect to `/me/` + flash "Password changed. Other sessions have been signed out." Current session is preserved via `update_session_auth_hash`; sibling DB sessions for the same user are deleted.
- User-menu Profile link is wired to `core:profile` (the dormant `{% url 'profile' as ... if %}` fallback that predated this view is removed).

## Deviations from issue text
- **PRG instead of render-on-success.** Issue suggests `render(...)` with flash on success; this PR uses redirect + `django.contrib.messages` to match `core/views/organization.py:settings_view` and avoid resubmit-on-refresh. Acceptance criterion "reload shows new values" is satisfied either way - the redirect IS the reload.
- **`base_picker.html` instead of `base_public.html`.** `base_public.html` has no top bar (used for unauthenticated screens). `base_picker.html` is the existing "authenticated, not org-scoped" shell used by `/orgs/` and is the right fit.
- **Single `me.html` template** instead of separate `me.html` + `password.html`; PRG collapses both flows.

## Reused from prior work
- `core/services/profile.py` (`update_profile`, `change_password`) and its tests in `tests/test_core_services_profile.py` are unchanged.
- Form helpers (`forms/_field.html`, `_errors.html`, `_submit.html`).
- `WeakPasswordError` / `WrongPasswordError` from `core/services/exceptions.py`.

## Test plan
- [x] `uv run pytest` -> 491 passed, 1 skipped (12 new view tests in `tests/test_views_profile.py`).
- [x] Manual end-to-end via Playwright against `runserver`:
  - [x] Anonymous `/me/` -> 302 to `/login/?next=/me/`.
  - [x] Login redirects via `next` to `/me/`; both forms render with current values.
  - [x] Save profile -> redirect + flash "Profile updated."; reload shows persisted Ada / Lovelace / fr-BE; user-menu summary reflects new name; flash is one-shot.
  - [x] Wrong current password -> 200 with inline "Current password is incorrect.", password unchanged.
  - [x] Mismatched new passwords -> 200 with "Passwords do not match.", password unchanged.
  - [x] Successful change -> redirect + flash; current session still authenticated, pre-created sibling DB session for same user deleted, new password works, old rejected.
  - [x] Top-bar Profile link resolves to `/me/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)