### PR TITLE
fix(2b): stub POS landing route to unblock operator login (#95)

### DIFF
--- a/core/services/login_redirect.py
+++ b/core/services/login_redirect.py
@@ -5,7 +5,7 @@ def login_redirect_for(user: User) -> str:
     # Whitepaper epic 2b §4 redirect rule:
     #   single active org membership -> /o/<slug>/
     #   OPERATOR with exactly one active LocationMembership in that org
-    #     -> /o/<slug>/l/<lslug>/pos/ (route reserved; 404 until POS epic)
+    #     -> /o/<slug>/l/<lslug>/pos/
     #   anything else (zero or multiple orgs) -> /orgs/
     memberships = list(
         OrganizationMembership.objects.filter(

--- a/core/urls.py
+++ b/core/urls.py
@@ -17,6 +17,7 @@ from .views.auth import (
 from .views.dashboard import dashboard
 from .views.design import design_kitchen_sink
 from .views.organization import settings_view as settings_organization
+from .views.pos import pos_location, pos_org
 
 app_name = "core"
 
@@ -60,6 +61,12 @@ urlpatterns: list[URLPattern] = [
         name="profile_password",
     ),
     path(route="o/<slug:slug>/", view=dashboard, name="org_dashboard"),
+    path(route="o/<slug:slug>/pos/", view=pos_org, name="pos_org"),
+    path(
+        route="o/<slug:slug>/l/<slug:lslug>/pos/",
+        view=pos_location,
+        name="pos_location",
+    ),
     path(
         route="o/<slug:slug>/settings/locations/",
         view=locations.list_view,

--- a/core/views/pos.py
+++ b/core/views/pos.py
@@ -1,0 +1,39 @@
+from django.http import HttpRequest, HttpResponse
+from django.shortcuts import get_object_or_404, render
+
+from core.decorators import permission_required
+from core.models import Location
+
+
+@permission_required()
+def pos_org(request: HttpRequest, slug: str) -> HttpResponse:  # noqa: ARG001
+    return render(
+        request,
+        "pos/coming_soon.html",
+        {
+            "organization": request.organization,  # type: ignore[attr-defined]
+            "location": None,
+        },
+    )
+
+
+@permission_required()
+def pos_location(
+    request: HttpRequest,
+    slug: str,  # noqa: ARG001
+    lslug: str,
+) -> HttpResponse:
+    location = get_object_or_404(
+        Location,
+        organization=request.organization,  # type: ignore[attr-defined]
+        slug=lslug,
+        is_active=True,
+    )
+    return render(
+        request,
+        "pos/coming_soon.html",
+        {
+            "organization": request.organization,  # type: ignore[attr-defined]
+            "location": location,
+        },
+    )

--- a/core/views/pos.py
+++ b/core/views/pos.py
@@ -1,8 +1,13 @@
-from django.http import HttpRequest, HttpResponse
+from django.http import Http404, HttpRequest, HttpResponse
 from django.shortcuts import get_object_or_404, render
 
 from core.decorators import permission_required
-from core.models import Location
+from core.models import (
+    Location,
+    LocationMembership,
+    OrganizationMembership,
+    Role,
+)
 
 
 @permission_required()
@@ -24,11 +29,25 @@ def pos_location(
     lslug: str,
 ) -> HttpResponse:
     location = get_object_or_404(
-        Location,
-        organization=request.organization,  # type: ignore[attr-defined]
+        Location.tenant_objects.for_request(request),
         slug=lslug,
         is_active=True,
     )
+    user = request.user
+    if not user.is_superuser:
+        membership = (
+            OrganizationMembership.tenant_objects.for_request(request)
+            .filter(user=user, is_active=True)
+            .first()
+        )
+        if membership and membership.role == Role.OPERATOR:
+            has_location = (
+                LocationMembership.tenant_objects.for_request(request)
+                .filter(user=user, location=location, is_active=True)
+                .exists()
+            )
+            if not has_location:
+                raise Http404
     return render(
         request,
         "pos/coming_soon.html",

--- a/templates/pos/coming_soon.html
+++ b/templates/pos/coming_soon.html
@@ -1,0 +1,10 @@
+{% extends "base_org.html" %}
+{% load i18n %}
+
+{% block main %}
+  <h1>{% trans "Point of sale" %}</h1>
+  <p>{% trans "The POS interface is coming soon." %}</p>
+  {% if location %}
+    <p>{% blocktrans with name=location.name %}Location: {{ name }}{% endblocktrans %}</p>
+  {% endif %}
+{% endblock %}

--- a/tests/test_auth_login_redirect.py
+++ b/tests/test_auth_login_redirect.py
@@ -102,6 +102,7 @@ def test_post_operator_single_location_redirects_to_pos() -> None:
 
     assert response.status_code == 302
     assert response["Location"] == "/o/acme/l/downtown/pos/"
+    assert client.get(response["Location"]).status_code == 200
 
 
 @pytest.mark.django_db

--- a/tests/test_auth_org_picker.py
+++ b/tests/test_auth_org_picker.py
@@ -115,3 +115,4 @@ def test_operator_single_location_redirects_to_pos() -> None:
 
     assert response.status_code == 302
     assert response["Location"] == "/o/acme/l/downtown/pos/"
+    assert client.get(response["Location"]).status_code == 200

--- a/tests/test_views_dashboard.py
+++ b/tests/test_views_dashboard.py
@@ -48,6 +48,7 @@ def test_operator_with_one_active_location_redirects_to_pos() -> None:
 
     assert response.status_code == 302
     assert response["Location"] == f"/o/{org.slug}/l/loc-a/pos/"
+    assert client.get(response["Location"]).status_code == 200
 
 
 @pytest.mark.django_db
@@ -67,6 +68,7 @@ def test_operator_with_multiple_locations_redirects_to_org_pos() -> None:
 
     assert response.status_code == 302
     assert response["Location"] == f"/o/{org.slug}/pos/"
+    assert client.get(response["Location"]).status_code == 200
 
 
 @pytest.mark.django_db
@@ -80,6 +82,7 @@ def test_operator_with_zero_locations_redirects_to_org_pos() -> None:
 
     assert response.status_code == 302
     assert response["Location"] == f"/o/{org.slug}/pos/"
+    assert client.get(response["Location"]).status_code == 200
 
 
 @pytest.mark.django_db
@@ -99,6 +102,7 @@ def test_operator_inactive_location_excluded_from_single_branch() -> None:
 
     assert response.status_code == 302
     assert response["Location"] == f"/o/{org.slug}/l/active-loc/pos/"
+    assert client.get(response["Location"]).status_code == 200
 
 
 @pytest.mark.django_db

--- a/tests/test_views_invitations.py
+++ b/tests/test_views_invitations.py
@@ -389,6 +389,7 @@ def test_accept_post_new_user_creates_user_and_memberships() -> None:
     )
 
     assert response.status_code == 302
+    assert client.get(response["Location"]).status_code == 200
     user = User.objects.get(email="newhire@example.be")
     assert OrganizationMembership.objects.filter(
         user=user, organization=org, is_active=True, role=Role.OPERATOR

--- a/tests/test_views_pos.py
+++ b/tests/test_views_pos.py
@@ -52,6 +52,21 @@ def test_pos_location_unknown_slug_returns_404() -> None:
 
 
 @pytest.mark.django_db
+def test_pos_location_operator_without_membership_returns_404() -> None:
+    membership = OrganizationMembershipFactory(role=Role.OPERATOR)
+    org = membership.organization
+    assigned = LocationFactory(organization=org, slug="assigned")
+    LocationFactory(organization=org, slug="other")
+    LocationMembershipFactory(user=membership.user, location=assigned)
+    client = Client()
+    client.force_login(membership.user)
+
+    response = client.get(f"/o/{org.slug}/l/other/pos/")
+
+    assert response.status_code == 404
+
+
+@pytest.mark.django_db
 def test_pos_location_inactive_location_returns_404() -> None:
     membership = OrganizationMembershipFactory(role=Role.ADMIN)
     org = membership.organization

--- a/tests/test_views_pos.py
+++ b/tests/test_views_pos.py
@@ -1,0 +1,98 @@
+import pytest
+from django.test import Client
+from django.urls import reverse
+
+from core.models import Role
+from tests.factories import (
+    LocationFactory,
+    LocationMembershipFactory,
+    OrganizationFactory,
+    OrganizationMembershipFactory,
+)
+
+
+@pytest.mark.django_db
+def test_pos_location_renders_for_operator() -> None:
+    membership = OrganizationMembershipFactory(role=Role.OPERATOR)
+    org = membership.organization
+    location = LocationFactory(organization=org, slug="downtown")
+    LocationMembershipFactory(user=membership.user, location=location)
+    client = Client()
+    client.force_login(membership.user)
+
+    response = client.get(f"/o/{org.slug}/l/downtown/pos/")
+
+    assert response.status_code == 200
+    assert b"coming soon" in response.content.lower()
+
+
+@pytest.mark.django_db
+def test_pos_location_renders_for_admin() -> None:
+    membership = OrganizationMembershipFactory(role=Role.ADMIN)
+    org = membership.organization
+    LocationFactory(organization=org, slug="downtown")
+    client = Client()
+    client.force_login(membership.user)
+
+    response = client.get(f"/o/{org.slug}/l/downtown/pos/")
+
+    assert response.status_code == 200
+
+
+@pytest.mark.django_db
+def test_pos_location_unknown_slug_returns_404() -> None:
+    membership = OrganizationMembershipFactory(role=Role.ADMIN)
+    org = membership.organization
+    client = Client()
+    client.force_login(membership.user)
+
+    response = client.get(f"/o/{org.slug}/l/nope/pos/")
+
+    assert response.status_code == 404
+
+
+@pytest.mark.django_db
+def test_pos_location_inactive_location_returns_404() -> None:
+    membership = OrganizationMembershipFactory(role=Role.ADMIN)
+    org = membership.organization
+    LocationFactory(organization=org, slug="closed", is_active=False)
+    client = Client()
+    client.force_login(membership.user)
+
+    response = client.get(f"/o/{org.slug}/l/closed/pos/")
+
+    assert response.status_code == 404
+
+
+@pytest.mark.django_db
+def test_pos_org_renders_for_operator() -> None:
+    membership = OrganizationMembershipFactory(role=Role.OPERATOR)
+    org = membership.organization
+    client = Client()
+    client.force_login(membership.user)
+
+    response = client.get(f"/o/{org.slug}/pos/")
+
+    assert response.status_code == 200
+
+
+@pytest.mark.django_db
+def test_pos_anonymous_redirects_to_login() -> None:
+    org = OrganizationFactory()
+
+    response = Client().get(f"/o/{org.slug}/pos/")
+
+    # Tenant middleware 404s anonymous users before permission_required
+    # gets a chance to redirect — that's existing behavior, see
+    # test_views_dashboard.test_anonymous_returns_404.
+    assert response.status_code == 404
+
+
+@pytest.mark.django_db
+def test_pos_urls_reverse() -> None:
+    org = OrganizationFactory()
+    assert reverse("core:pos_org", args=[org.slug]) == f"/o/{org.slug}/pos/"
+    assert (
+        reverse("core:pos_location", args=[org.slug, "downtown"])
+        == f"/o/{org.slug}/l/downtown/pos/"
+    )


### PR DESCRIPTION
## Summary
- Adds `pos_org` (`/o/<slug>/pos/`) and `pos_location` (`/o/<slug>/l/<lslug>/pos/`) stub views rendering a "POS coming soon" page; both URLs were referenced by `login_redirect_for` and the dashboard view but never registered, so every operator-onboarding flow 404'd.
- Stub extends `base_org.html` so the `user_menu` sign-out remains reachable - issue #95 noted "no logout button on Django's debug 404 page" as the user-blocking trigger.
- Existing redirect tests (`test_views_dashboard`, `test_auth_login_redirect`, `test_auth_org_picker`, `test_views_invitations`) now follow the 302 and assert 200 to prevent the regression re-shipping. Adds `tests/test_views_pos.py` covering operator/admin access, unknown/inactive `lslug` -> 404, anonymous flow, and URL reversal.

Per epic 2c §4 operators must only see POS, so issue option (b) "fall through to `/o/<slug>/`" violates spec - implemented option (a) stub.

Closes #95.

## Test plan
- [x] `uv run pytest` -> 498 passed, 1 skipped (pre-existing)
- [x] `uv run ruff check core/ tests/` clean
- [x] `uv run pyright core/views/pos.py core/urls.py` clean
- [x] `uv run python manage.py check` clean
- [x] Manual end-to-end via Playwright:
  - Operator with 1 active location -> `/o/<slug>/l/<lslug>/pos/` 200, sign-out -> `/`
  - Operator with 0 locations -> `/o/<slug>/pos/` 200, sign-out -> `/`
  - Admin login still lands on `/o/<slug>/` dashboard (unchanged)
  - Direct GET `/o/<slug>/l/nonexistent/pos/` -> 404 (correct)

🤖 Generated with [Claude Code](https://claude.com/claude-code)