### PR TITLE
fix(i18n): wire resolve_locale via LocalePreferenceMiddleware (closes #97)

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -38,6 +38,7 @@ MIDDLEWARE = [
     "django.middleware.csrf.CsrfViewMiddleware",
     "django.contrib.auth.middleware.AuthenticationMiddleware",
     "core.middleware.TenantMiddleware",
+    "core.middleware.LocalePreferenceMiddleware",
     "django.contrib.messages.middleware.MessageMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
     "django_htmx.middleware.HtmxMiddleware",

--- a/core/i18n.py
+++ b/core/i18n.py
@@ -7,14 +7,16 @@ from core.models import Organization
 def resolve_locale(
     user: AbstractBaseUser | AnonymousUser | None,
     org: Organization | None,
-) -> str:
-    """User preference > org default > system default."""
+    *,
+    default: str | None = settings.LANGUAGE_CODE,
+) -> str | None:
+    """User preference > org default > `default`."""
     if user is not None and getattr(user, "is_authenticated", False):
         pref = getattr(user, "preferred_language", "") or ""
         if pref:
             return pref
     if org is not None:
-        default = getattr(org, "default_language", "") or ""
-        if default:
-            return default
-    return settings.LANGUAGE_CODE
+        explicit = getattr(org, "default_language", "") or ""
+        if explicit:
+            return explicit
+    return default

--- a/core/middleware.py
+++ b/core/middleware.py
@@ -2,7 +2,9 @@ import re
 from collections.abc import Callable
 
 from django.http import Http404, HttpRequest, HttpResponse
+from django.utils import translation
 
+from core.i18n import resolve_locale
 from core.models import Organization
 
 _TENANT_PATH_RE = re.compile(r"^/o/(?P<slug>[a-z0-9-]+)/")
@@ -40,4 +42,23 @@ class TenantMiddleware:
             raise Http404
 
         request.organization = org  # type: ignore[attr-defined]
+        return self.get_response(request)
+
+
+class LocalePreferenceMiddleware:
+    def __init__(
+        self,
+        get_response: Callable[[HttpRequest], HttpResponse],
+    ) -> None:
+        self.get_response = get_response
+
+    def __call__(self, request: HttpRequest) -> HttpResponse:
+        lang = resolve_locale(
+            getattr(request, "user", None),
+            getattr(request, "organization", None),
+            default=None,
+        )
+        if lang:
+            translation.activate(lang)
+            request.LANGUAGE_CODE = lang  # type: ignore[attr-defined]
         return self.get_response(request)

--- a/tests/test_i18n.py
+++ b/tests/test_i18n.py
@@ -5,7 +5,11 @@ from django.test import Client
 from django.utils import translation
 
 from core.i18n import resolve_locale
-from tests.factories import OrganizationFactory, UserFactory
+from tests.factories import (
+    OrganizationFactory,
+    OrganizationMembershipFactory,
+    UserFactory,
+)
 
 
 @pytest.mark.django_db
@@ -41,9 +45,48 @@ def test_anonymous_user_no_org_falls_back_to_system_default() -> None:
     assert resolve_locale(AnonymousUser(), None) == settings.LANGUAGE_CODE
 
 
+def test_resolve_locale_returns_default_when_no_preference() -> None:
+    assert resolve_locale(None, None, default=None) is None
+
+
 def test_locale_middleware_honors_accept_language() -> None:
     client = Client()
     response = client.get("/", HTTP_ACCEPT_LANGUAGE="fr-BE")
+    assert response["Content-Language"].lower().startswith("fr")
+
+
+@pytest.mark.django_db
+def test_authenticated_user_preferred_language_activates_on_request() -> None:
+    user = UserFactory(preferred_language="fr-BE", password="pw12345!")
+    client = Client()
+    assert client.login(email=user.email, password="pw12345!")
+    response = client.get("/me/")
+    assert response.status_code == 200
+    assert response["Content-Language"].lower().startswith("fr")
+    assert "modifier le mot de passe" in response.content.decode().lower()
+
+
+@pytest.mark.django_db
+def test_org_default_language_activates_on_org_pages() -> None:
+    membership = OrganizationMembershipFactory(
+        user__preferred_language="",
+        user__password="pw12345!",
+        organization__default_language="nl-BE",
+    )
+    client = Client()
+    assert client.login(email=membership.user.email, password="pw12345!")
+    response = client.get(f"/o/{membership.organization.slug}/")
+    assert response.status_code == 200
+    assert response["Content-Language"].lower().startswith("nl")
+
+
+@pytest.mark.django_db
+def test_user_without_preference_falls_back_to_accept_language() -> None:
+    user = UserFactory(preferred_language="", password="pw12345!")
+    client = Client()
+    assert client.login(email=user.email, password="pw12345!")
+    response = client.get("/me/", HTTP_ACCEPT_LANGUAGE="fr-BE")
+    assert response.status_code == 200
     assert response["Content-Language"].lower().startswith("fr")
 
 


### PR DESCRIPTION
Closes #97.

## Summary
- `User.preferred_language` and `Organization.default_language` were saved to DB but had no rendering effect: `core/i18n.resolve_locale` was defined but never called by any view or middleware.
- New `core.middleware.LocalePreferenceMiddleware` runs after `AuthenticationMiddleware` + `TenantMiddleware`, calls `resolve_locale(user, org, default=None)`, and `translation.activate(...)` only when an explicit preference exists. Anonymous-without-org and authenticated-without-preference paths still fall through to Django's `LocaleMiddleware` (cookie / Accept-Language).
- `resolve_locale` gains a keyword-only `default` so the middleware can opt out of the system-default fallback without breaking the existing fallback semantics that other callers / tests rely on.

## Test plan
- [x] `uv run pytest` - 505 passed (4 new integration tests in `tests/test_i18n.py`).
- [x] `uv run ruff check . && uv run ruff format --check .` - clean.
- [x] `uv run pyright core/i18n.py core/middleware.py tests/test_i18n.py` - 0 errors.
- [x] Manual repro via Playwright: log in, `/me/` -> Preferred language = Français -> Save -> reload now renders `<html lang="fr-be">` with French copy ("Enregistrer", "Modifier le mot de passe", etc.). Same flow on `master` left the page in `en-us` and hid the language switcher, leaving the user stuck.

## Out of scope (flagged for follow-ups)
- A few strings on `/me/` (e.g. `_("Preferred language")`, `_("Profile updated.")`, page H1) are missing from the fr_BE / nl_BE / de_DE catalogs - translation-coverage gap, not wiring.
- `lang_switcher.html` partial supports anonymous users but is only included from `user_menu.html` (auth-only); anonymous users have no in-app way to change language.
- `Organization.default_language` defaults to `settings.LANGUAGE_CODE`, so every org has a default even without admin action; org pages will activate that for users without `preferred_language`. Matches the documented `user > org > system` priority but worth flagging.